### PR TITLE
Rename below crates to have `below-` namespace prefix

### DIFF
--- a/resctl/below/Cargo.toml
+++ b/resctl/below/Cargo.toml
@@ -2,11 +2,8 @@
 name = "resctl_below"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [[bin]]

--- a/resctl/below/Cargo.toml
+++ b/resctl/below/Cargo.toml
@@ -15,14 +15,14 @@ name = "below"
 path = "src/main.rs"
 
 [dependencies]
+common = { package = "below-common", path = "common" }
+dump = { package = "below-dump", path = "dump" }
+model = { package = "below-model", path = "model" }
+store = { package = "below-store", path = "store" }
 below-thrift = { path = "if" }
+view = { package = "below-view", path = "view" }
 cgroupfs = { path = "../common/cgroupfs" }
-common = { path = "common" }
-dump = { path = "dump" }
-model = { path = "model" }
-procfs = { path = "../common/procfs" }
-store = { path = "store" }
-view = { path = "view" }
+procfs = { package = "fb_procfs", path = "../common/procfs" }
 slog_glog_fmt = { git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
 stats = { git = "https://github.com/facebookexperimental/rust-shed.git", branch = "master" }
 anyhow = "1.0"

--- a/resctl/below/Cargo.toml
+++ b/resctl/below/Cargo.toml
@@ -2,8 +2,12 @@
 name = "resctl_below"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "An interactive tool to view and record historical system data"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
+readme = "../../README.md"
 include = ["src/**/*.rs"]
 
 [[bin]]

--- a/resctl/below/below_derive/Cargo.toml
+++ b/resctl/below/below_derive/Cargo.toml
@@ -2,8 +2,11 @@
 name = "below_derive"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "Proc macros for below"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [lib]

--- a/resctl/below/below_derive/Cargo.toml
+++ b/resctl/below/below_derive/Cargo.toml
@@ -2,11 +2,8 @@
 name = "below_derive"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [lib]

--- a/resctl/below/common/Cargo.toml
+++ b/resctl/below/common/Cargo.toml
@@ -2,8 +2,11 @@
 name = "common"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "Common below code"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/common/Cargo.toml
+++ b/resctl/below/common/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "common"
+name = "below-common"
 edition = "2018"
 version = "0.1.0"
 authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']

--- a/resctl/below/common/Cargo.toml
+++ b/resctl/below/common/Cargo.toml
@@ -2,11 +2,8 @@
 name = "common"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/dump/Cargo.toml
+++ b/resctl/below/dump/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dump"
+name = "below-dump"
 edition = "2018"
 version = "0.1.0"
 authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
@@ -10,11 +10,11 @@ repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]
+common = { package = "below-common", path = "../common" }
+model = { package = "below-model", path = "../model" }
+render = { package = "below-render", path = "../render" }
+store = { package = "below-store", path = "../store" }
 below_derive = { path = "../below_derive" }
-common = { path = "../common" }
-model = { path = "../model" }
-render = { path = "../render" }
-store = { path = "../store" }
 anyhow = "1.0"
 once_cell = "1.4"
 regex = "1.4.2"

--- a/resctl/below/dump/Cargo.toml
+++ b/resctl/below/dump/Cargo.toml
@@ -2,8 +2,11 @@
 name = "dump"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "Dump crate for below"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/dump/Cargo.toml
+++ b/resctl/below/dump/Cargo.toml
@@ -2,11 +2,8 @@
 name = "dump"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/if/Cargo.toml
+++ b/resctl/below/if/Cargo.toml
@@ -2,11 +2,8 @@
 name = "below-thrift"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["thrift_lib.rs"]
 build = "thrift_build.rs"
 

--- a/resctl/below/if/Cargo.toml
+++ b/resctl/below/if/Cargo.toml
@@ -2,8 +2,11 @@
 name = "below-thrift"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "Thrift definitions for below"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
 include = ["thrift_lib.rs"]
 build = "thrift_build.rs"
 

--- a/resctl/below/model/Cargo.toml
+++ b/resctl/below/model/Cargo.toml
@@ -2,11 +2,8 @@
 name = "model"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/model/Cargo.toml
+++ b/resctl/below/model/Cargo.toml
@@ -2,8 +2,11 @@
 name = "model"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "Model crate for below"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/model/Cargo.toml
+++ b/resctl/below/model/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "model"
+name = "below-model"
 edition = "2018"
 version = "0.1.0"
 authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
@@ -13,7 +13,7 @@ include = ["src/**/*.rs"]
 below-thrift = { path = "../if" }
 below_derive = { path = "../below_derive" }
 cgroupfs = { path = "../../common/cgroupfs" }
-procfs = { path = "../../common/procfs" }
+procfs = { package = "fb_procfs", path = "../../common/procfs" }
 anyhow = "1.0"
 hostname = "0.3"
 os_info = "=2.0.1"

--- a/resctl/below/render/Cargo.toml
+++ b/resctl/below/render/Cargo.toml
@@ -2,8 +2,11 @@
 name = "render"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "Render crate for below"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/render/Cargo.toml
+++ b/resctl/below/render/Cargo.toml
@@ -2,11 +2,8 @@
 name = "render"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/render/Cargo.toml
+++ b/resctl/below/render/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "render"
+name = "below-render"
 edition = "2018"
 version = "0.1.0"
 authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
@@ -10,5 +10,5 @@ repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]
-common = { path = "../common" }
-model = { path = "../model" }
+common = { package = "below-common", path = "../common" }
+model = { package = "below-model", path = "../model" }

--- a/resctl/below/store/Cargo.toml
+++ b/resctl/below/store/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "store"
+name = "below-store"
 edition = "2018"
 version = "0.1.0"
 authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
@@ -10,9 +10,9 @@ repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]
+common = { package = "below-common", path = "../common" }
+model = { package = "below-model", path = "../model" }
 below-thrift = { path = "../if" }
-common = { path = "../common" }
-model = { path = "../model" }
 fbthrift = { git = "https://github.com/facebook/fbthrift.git", branch = "master" }
 anyhow = "1.0"
 futures = { version = "0.3.5", features = ["async-await", "compat"] }

--- a/resctl/below/store/Cargo.toml
+++ b/resctl/below/store/Cargo.toml
@@ -2,11 +2,8 @@
 name = "store"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/store/Cargo.toml
+++ b/resctl/below/store/Cargo.toml
@@ -2,8 +2,11 @@
 name = "store"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "Store crate for below"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/view/Cargo.toml
+++ b/resctl/below/view/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "view"
+name = "below-view"
 edition = "2018"
 version = "0.1.0"
 authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
@@ -10,10 +10,10 @@ repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]
-common = { path = "../common" }
-model = { path = "../model" }
-render = { path = "../render" }
-store = { path = "../store" }
+common = { package = "below-common", path = "../common" }
+model = { package = "below-model", path = "../model" }
+render = { package = "below-render", path = "../render" }
+store = { package = "below-store", path = "../store" }
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 cursive = { version = "0.15.0", default-features = false, features = ["crossterm", "termion"] }

--- a/resctl/below/view/Cargo.toml
+++ b/resctl/below/view/Cargo.toml
@@ -2,11 +2,8 @@
 name = "view"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/below/view/Cargo.toml
+++ b/resctl/below/view/Cargo.toml
@@ -2,8 +2,11 @@
 name = "view"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "View crate for below"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/resctl/common/cgroupfs/Cargo.toml
+++ b/resctl/common/cgroupfs/Cargo.toml
@@ -2,8 +2,12 @@
 name = "cgroupfs"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "A crate for reading cgroupv2 data"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
+readme = "README"
 include = ["src/lib.rs"]
 
 [dependencies]

--- a/resctl/common/cgroupfs/Cargo.toml
+++ b/resctl/common/cgroupfs/Cargo.toml
@@ -2,11 +2,8 @@
 name = "cgroupfs"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/lib.rs"]
 
 [dependencies]

--- a/resctl/common/cgroupfs/if/Cargo.toml
+++ b/resctl/common/cgroupfs/if/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cgroupfs-thrift"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
 include = ["thrift_lib.rs"]
 build = "thrift_build.rs"

--- a/resctl/common/cgroupfs/if/Cargo.toml
+++ b/resctl/common/cgroupfs/if/Cargo.toml
@@ -2,11 +2,8 @@
 name = "cgroupfs-thrift"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["thrift_lib.rs"]
 build = "thrift_build.rs"
 

--- a/resctl/common/procfs/Cargo.toml
+++ b/resctl/common/procfs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "procfs"
+name = "fb_procfs"
 edition = "2018"
 version = "0.1.0"
 authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']

--- a/resctl/common/procfs/Cargo.toml
+++ b/resctl/common/procfs/Cargo.toml
@@ -2,11 +2,8 @@
 name = "procfs"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["src/lib.rs"]
 
 [dependencies]

--- a/resctl/common/procfs/Cargo.toml
+++ b/resctl/common/procfs/Cargo.toml
@@ -2,8 +2,12 @@
 name = "procfs"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
+description = "A crate for reading procfs"
+homepage = "https://github.com/facebookincubator/resctl"
+repository = "https://github.com/facebookincubator/resctl"
+readme = "README"
 include = ["src/lib.rs"]
 
 [dependencies]

--- a/resctl/common/procfs/if/Cargo.toml
+++ b/resctl/common/procfs/if/Cargo.toml
@@ -2,7 +2,7 @@
 name = "procfs-thrift"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook']
+authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
 license = "Apache-2.0"
 include = ["thrift_lib.rs"]
 build = "thrift_build.rs"

--- a/resctl/common/procfs/if/Cargo.toml
+++ b/resctl/common/procfs/if/Cargo.toml
@@ -2,11 +2,8 @@
 name = "procfs-thrift"
 edition = "2018"
 version = "0.1.0"
-authors = ['Facebook', 'Daniel Xu <dlxu@fb.com>']
+authors = ['Facebook']
 license = "Apache-2.0"
-description = "An interactive tool to view and record historical system data"
-homepage = "https://github.com/facebookincubator/resctl"
-repository = "https://github.com/facebookincubator/resctl"
 include = ["thrift_lib.rs"]
 build = "thrift_build.rs"
 


### PR DESCRIPTION
Summary:
All the crates that are uploaded to crates.io have the namespace
prefix. This diff generates that as part of autocargo build which will help
me maintain less patches in my fork.

Differential Revision: D26026742

