### PR TITLE
Ignore --use-cbor in open source and improve handling when reading/writing unsupported format

### DIFF
--- a/resctl/below/src/main.rs
+++ b/resctl/below/src/main.rs
@@ -600,11 +600,14 @@ fn record(
     }
 
     // TODO(T92471373): Remove --use-cbor flag and hardcode format as CBOR.
-    let format = if use_cbor {
+    // This is already the case for open source.
+    let format = if !cfg!(fbcode_build) || use_cbor {
         store::Format::Cbor
     } else {
         store::Format::Thrift
     };
+
+
     let mut store = store::StoreWriter::new(&below_config.store_dir, compress, format)?;
     let mut stats = statistics::Statistics::new();
 

--- a/resctl/below/store/src/lib.rs
+++ b/resctl/below/store/src/lib.rs
@@ -625,7 +625,7 @@ pub fn read_next_sample<P: AsRef<Path>>(
                 Format::Thrift
             };
             let data_frame = deserialize_frame(data_decompressed.data(), format)
-                .context("Failed to deserialized data frame")?;
+                .context("Failed to deserialize data frame")?;
 
             let ts = std::time::UNIX_EPOCH + std::time::Duration::from_secs(index_entry.timestamp);
             return Ok(Some((ts, data_frame)));

--- a/resctl/below/store/src/open_source/mod.rs
+++ b/resctl/below/store/src/open_source/mod.rs
@@ -18,16 +18,28 @@ use anyhow::{bail, Result};
 
 use crate::{DataFrame, Format};
 
-/// Serialize a data frame. As there is no support for Thrift in open source,
-/// format is ignored and we serialize as CBOR.
-pub fn serialize_frame(data: &DataFrame, _format: Format) -> Result<bytes::Bytes> {
-    let bytes = serde_cbor::to_vec(data)?;
-    Ok(bytes::Bytes::from(bytes))
+/// Deserialize a single data frame with `format` format.
+pub fn serialize_frame(data: &DataFrame, format: Format) -> Result<bytes::Bytes> {
+    match format {
+        Format::Thrift => {
+            bail!("Data format Thrift is unsupported");
+        }
+        Format::Cbor => {
+            let bytes = serde_cbor::to_vec(data)?;
+            Ok(bytes::Bytes::from(bytes))
+        }
+    }
 }
 
-/// Serialize a data frame. As there is no support for Thrift in open source,
-/// format is ignored and we deserialize as CBOR.
-pub fn deserialize_frame(bytes: &[u8], _format: Format) -> Result<DataFrame> {
-    let data_frame = serde_cbor::from_slice(bytes)?;
-    Ok(data_frame)
+/// Deserialize a single data frame with `format` format.
+pub fn deserialize_frame(bytes: &[u8], format: Format) -> Result<DataFrame> {
+    match format {
+        Format::Thrift => {
+            bail!("Data format Thrift is unsupported");
+        }
+        Format::Cbor => {
+            let data_frame = serde_cbor::from_slice(bytes)?;
+            Ok(data_frame)
+        }
+    }
 }


### PR DESCRIPTION
Summary:
This adds a shim to effectively hardcode --use-cbor in the open source
build. This way the CBOR bit is always set. Right now, the CBOR bit
can be unset despite the data being serialized as CBOR.

It also makes serialization/deserialization fail if the requested type
is Thrift.

This will break ability to read CBOR data that does not have the CBOR
bit set!

Differential Revision: D29041250

