### PR TITLE
Update docs and Dockerfile for build script based build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /rustup.sh
 RUN chmod +x /rustup.sh
 RUN bash /rustup.sh -y
 
-# Install libbpf-rs tooling
-RUN /root/.cargo/bin/cargo install libbpf-cargo
-
 ADD . /resctl
 # Build below
 WORKDIR resctl
-RUN /root/.cargo/bin/cargo libbpf make -- --release --package below
+RUN /root/.cargo/bin/cargo build --release --package below
 
 # Run tests if requested
 RUN if [[ -n "$RUN_TESTS" ]]; then     \

--- a/resctl/below/docs/building.md
+++ b/resctl/below/docs/building.md
@@ -15,18 +15,6 @@ release mode.
 In the root of the repository:
 
 ```shell
-$ cargo install libbpf-cargo
-$ cargo libbpf make -- --release
-$ cargo test
-```
-
-`cargo libbpf make` is a convenience wrapper for the BPF components. Alternatively,
-you could do:
-
-```shell
-$ cargo install libbpf-cargo
-$ cargo libbpf build
-$ cargo libbpf gen
 $ cargo build --release
 $ cargo test
 ```


### PR DESCRIPTION
Summary: No need for the libbpf-cargo subcommand nonsense anymore.

Differential Revision: D29118262

