### PR TITLE
Ensure two samples are at least 1s apart

### DIFF
--- a/below/src/main.rs
+++ b/below/src/main.rs
@@ -702,9 +702,13 @@ fn record(
         stats.report_store_size(below_config.store_dir.as_path());
 
         let collect_duration = Instant::now().duration_since(collect_instant);
-        if collect_duration < interval {
-            std::thread::sleep(interval - collect_duration);
-        }
+        // Sleep for at least 1s to avoid sample collision
+        let sleep_duration = if interval > collect_duration {
+            std::cmp::max(Duration::from_secs(1), interval - collect_duration)
+        } else {
+            Duration::from_secs(1)
+        };
+        std::thread::sleep(sleep_duration);
     }
 }
 


### PR DESCRIPTION
Summary: below samples have seconds granularity, which is enforced at the index entry timestamp. If two samples are recorded at the same second, we can't tell them apart. Zero-second collection interval will also mess up rate calculations. Let's make sure every two samples are at least 1s apart.

Reviewed By: boyuni

Differential Revision: D29642266

