### PR TITLE
Remove libbpf-dev as build time dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get install -y \
   clang \
   curl \
   git \
-  libbpf-dev \
   libelf-dev \
   libncursesw5-dev \
   libssl-dev \

--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -15,7 +15,7 @@ common = { package = "below-common", version = "0.2.0", path = "common" }
 config = { package = "below-config", version = "0.2.0", path = "config" }
 cursive = { version = "0.16.0", features = ["crossterm", "termion"], default-features = false }
 dump = { package = "below-dump", version = "0.2.0", path = "dump" }
-libbpf-rs = "0.11.1"
+libbpf-rs = "0.11.2"
 libc = "0.2.86"
 model = { package = "below-model", version = "0.2.0", path = "model" }
 once_cell = "1.4"
@@ -39,7 +39,7 @@ rand = { version = "0.7", features = ["small_rng"] }
 tempdir = "0.3"
 
 [build-dependencies]
-libbpf-cargo = "0.7.2"
+libbpf-cargo = "0.8.0"
 
 [features]
 enable_backtrace = []

--- a/docs/building.md
+++ b/docs/building.md
@@ -2,7 +2,6 @@
 
 Several dependencies need to be installed before we can build.
 
-* libbpf-dev (for headers)
 * libz (dynamically linked)
 * libelf (dynamically linked)
 * libncursesw (dynamically linked)


### PR DESCRIPTION
Summary:
We no longer need host-installed libbpf API headers when
building below on the latest libbpf-cargo.

Differential Revision: D29740874

