### PR TITLE
Fix procfs when reading cgroup membership

### DIFF
--- a/below/procfs/src/lib.rs
+++ b/below/procfs/src/lib.rs
@@ -556,20 +556,19 @@ impl ProcReader {
         let path = path.as_ref().join("cgroup");
         let file = File::open(&path).map_err(|e| Error::IoError(path.clone(), e))?;
         let buf_reader = BufReader::new(file);
-        let pid_line = buf_reader.lines().next().map_or_else(
-            || Err(Error::InvalidFileFormat(path.clone())),
-            |line| line.map_err(|e| Error::IoError(path.clone(), e)),
-        )?;
 
-        // cgroup V2
-        if pid_line.len() > 3 && pid_line.starts_with("0::") {
-            return Ok(pid_line[3..].to_string());
-        }
-
-        // legacy cgroup will have multiple lines with the first line of [0-9]+:pids:PATH
-        if let Some(pid_idx) = pid_line.find(":pids:") {
-            if pid_idx + 6 < pid_line.len() {
-                return Ok(pid_line[pid_idx + 6..].to_string());
+        for line in buf_reader.lines() {
+            let line = line.map_err(|e| Error::IoError(path.clone(), e))?;
+            // Lines contain three colon separated fields:
+            //   hierarchy-ID:controller-list:cgroup-path
+            // A line starting with "0::" would be an entry for cgroup v2.
+            // Otherwise, the line containing "pids" controller is what we want
+            // for cgroup v1.
+            let parts: Vec<_> = line.split(':').collect();
+            if parts.len() == 3 {
+                if (parts[0] == "0" && parts[1] == "") || parts[1].split(',').any(|c| c == "pids") {
+                    return Ok(parts[2].to_owned());
+                }
             }
         }
 


### PR DESCRIPTION
When reading cgroup membership, we currently assume that the cgroup v2
line will be first in /proc/[pid]/cgroup. This is not necessarily the
case. Instead let's take the first line that starts with "0::".

Tested on ubuntu where

```
$ cat /proc/1/cgroup
12:blkio:/init.scope
11:pids:/init.scope
8:memory:/init.scope
7:freezer:/
4:devices:/init.scope
2:cpu,cpuacct:/init.scope
1:name=systemd:/init.scope
0::/init.scope
```

This should fix #8105.