### PR TITLE
Add support for configurable cgroup root

### DIFF
--- a/below/config/Cargo.toml
+++ b/below/config/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
+cgroupfs = { version = "0.3.0", path = "../cgroupfs" }
 once_cell = "1.4"
 serde = { version = "1.0.126", features = ["derive", "rc"] }
 toml = "=0.5.7"

--- a/below/config/src/lib.rs
+++ b/below/config/src/lib.rs
@@ -36,6 +36,7 @@ pub static BELOW_CONFIG: OnceCell<BelowConfig> = OnceCell::new();
 pub struct BelowConfig {
     pub log_dir: PathBuf,
     pub store_dir: PathBuf,
+    pub cgroup_root: PathBuf,
     pub cgroup_filter_out: String,
     /// store: Disable StoreCursor and use old read_next_sample. Default: false
     pub killswitch_store_cursor: bool,
@@ -46,6 +47,7 @@ impl Default for BelowConfig {
         BelowConfig {
             log_dir: BELOW_DEFAULT_LOG.into(),
             store_dir: BELOW_DEFAULT_STORE.into(),
+            cgroup_root: cgroupfs::DEFAULT_CG_ROOT.into(),
             cgroup_filter_out: String::new(),
             killswitch_store_cursor: false,
         }

--- a/below/config/src/test.rs
+++ b/below/config/src/test.rs
@@ -26,6 +26,10 @@ fn test_config_default() {
         below_config.store_dir.to_string_lossy(),
         "/var/log/below/store"
     );
+    assert_eq!(
+        below_config.cgroup_root.to_string_lossy(),
+        cgroupfs::DEFAULT_CG_ROOT
+    );
     assert_eq!(below_config.cgroup_filter_out, String::new());
     assert_eq!(below_config.killswitch_store_cursor, false);
 }
@@ -67,6 +71,7 @@ fn test_config_load_success() {
     let config_str = r#"
         log_dir = '/var/log/below'
         store_dir = '/var/log/below'
+        cgroup_root = '/sys/fs/cgroup'
         cgroup_filter_out = 'user.slice'
         killswitch_store_cursor = true
         # I'm a comment
@@ -82,6 +87,7 @@ fn test_config_load_success() {
     };
     assert_eq!(below_config.log_dir.to_string_lossy(), "/var/log/below");
     assert_eq!(below_config.store_dir.to_string_lossy(), "/var/log/below");
+    assert_eq!(below_config.cgroup_root.to_string_lossy(), "/sys/fs/cgroup");
     assert_eq!(below_config.cgroup_filter_out, "user.slice");
     assert_eq!(below_config.killswitch_store_cursor, true);
 }

--- a/below/src/main.rs
+++ b/below/src/main.rs
@@ -639,6 +639,7 @@ fn record(
         let collect_instant = Instant::now();
 
         let collected_sample = model::collect_sample(
+            &below_config.cgroup_root,
             &exit_buffer,
             collect_io_stat,
             &logger,
@@ -724,7 +725,8 @@ fn live_local(
     let (exit_buffer, bpf_errs) = start_exitstat(logger.clone(), debug);
     let mut bpf_err_warned = false;
 
-    let mut collector = model::Collector::new(exit_buffer);
+    let mut collector =
+        model::Collector::new_with_cgroup_root(below_config.cgroup_root.clone(), exit_buffer);
     logutil::set_current_log_target(logutil::TargetLog::File);
     // Prepare advance obj for pause mode
     let mut adv = new_advance_local(

--- a/below/src/test.rs
+++ b/below/src/test.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tempdir::TempDir;
@@ -28,10 +29,19 @@ fn record_replay_integration() {
     let mut store =
         store::StoreWriter::new(&dir, false, store::Format::Cbor).expect("Failed to create store");
 
+    let cgroup_root = Path::new(cgroupfs::DEFAULT_CG_ROOT).to_path_buf();
+
     // Collect a sample
     let logger = get_logger();
-    let sample = collect_sample(&Default::default(), true, &logger, false, &None)
-        .expect("failed to collect sample");
+    let sample = collect_sample(
+        &cgroup_root,
+        &Default::default(),
+        true,
+        &logger,
+        false,
+        &None,
+    )
+    .expect("failed to collect sample");
 
     // Validate some data in the sample
     sample
@@ -110,12 +120,21 @@ fn advance_forward_and_reverse() {
     let mut store =
         store::StoreWriter::new(&dir, false, store::Format::Cbor).expect("Failed to create store");
 
+    let cgroup_root = Path::new(cgroupfs::DEFAULT_CG_ROOT).to_path_buf();
+
     // Collect and store the same sample 3 times
     let timestamp = 554433;
     let unix_ts = UNIX_EPOCH + Duration::from_secs(timestamp);
     let logger = get_logger();
-    let sample = collect_sample(&Default::default(), true, &logger, false, &None)
-        .expect("failed to collect sample");
+    let sample = collect_sample(
+        &cgroup_root,
+        &Default::default(),
+        true,
+        &logger,
+        false,
+        &None,
+    )
+    .expect("failed to collect sample");
     for i in 0..3 {
         let df = DataFrame {
             sample: sample.clone(),
@@ -160,18 +179,34 @@ fn advance_forward_and_reverse() {
 
 #[test]
 fn disable_io_stat() {
+    let cgroup_root = Path::new(cgroupfs::DEFAULT_CG_ROOT).to_path_buf();
     let logger = get_logger();
-    let sample = collect_sample(&Default::default(), false, &logger, false, &None)
-        .expect("failed to collect sample");
+    let sample = collect_sample(
+        &cgroup_root,
+        &Default::default(),
+        false,
+        &logger,
+        false,
+        &None,
+    )
+    .expect("failed to collect sample");
 
     assert_eq!(sample.cgroup.io_stat, None);
 }
 
 #[test]
 fn disable_disk_stat() {
+    let cgroup_root = Path::new(cgroupfs::DEFAULT_CG_ROOT).to_path_buf();
     let logger = get_logger();
-    let sample = collect_sample(&Default::default(), false, &logger, true, &None)
-        .expect("failed to collect sample");
+    let sample = collect_sample(
+        &cgroup_root,
+        &Default::default(),
+        false,
+        &logger,
+        true,
+        &None,
+    )
+    .expect("failed to collect sample");
     assert!(sample.system.disks.is_empty());
 }
 


### PR DESCRIPTION
cgroup2 isn't necessarily mounted at /sys/fs/cgroup. Let's add support
for that.