### PR TITLE
Disable Thrift test in open source

### DIFF
--- a/below/store/src/cursor.rs
+++ b/below/store/src/cursor.rs
@@ -823,17 +823,20 @@ mod tests {
             Format::Cbor,
         );
     }
+
     #[cfg(fbcode_build)]
     #[test]
     fn read_thrift() {
         simple_put_read(CompressionMode::None, Format::Thrift);
     }
+
     #[cfg(fbcode_build)]
     #[test]
     fn read_compressed_thrift() {
         simple_put_read(CompressionMode::Zstd, Format::Thrift);
     }
 
+    #[cfg(fbcode_build)]
     #[test]
     fn read_dict_compressed_thrift() {
         simple_put_read(


### PR DESCRIPTION
Summary:
cursor::tests::read_dict_compressed_thrift is failing because Thrift
tests don't work in open source.

Differential Revision: D33432457

