### PR TITLE
Fix all build warning except those from bindgen

### DIFF
--- a/below/below_derive/src/queriable.rs
+++ b/below/below_derive/src/queriable.rs
@@ -125,11 +125,9 @@ fn get_queriable_struct_props(ast: &DeriveInput) -> syn::Result<QueriableStructP
     })
 }
 
-#[derive(Clone, Debug)]
 struct QueriableFieldProps {
     pub ignore: bool,
     pub subquery: Option<syn::Type>,
-    pub preferred_name: Ident,
     pub ident: Ident,
     pub variant_name: Ident,
     pub option_type: Option<syn::Type>,
@@ -182,7 +180,6 @@ fn get_queriable_field_props(field: &Field) -> syn::Result<QueriableFieldProps> 
     Ok(QueriableFieldProps {
         ignore,
         subquery,
-        preferred_name,
         ident,
         variant_name,
         option_type,

--- a/below/common/src/fileutil.rs
+++ b/below/common/src/fileutil.rs
@@ -33,7 +33,7 @@ mod tests {
     use tempdir::TempDir;
 
     fn make_file<P: AsRef<Path>>(path: P, size: u64) {
-        let mut file = File::create(&path).expect("Failed to create file");
+        let file = File::create(&path).expect("Failed to create file");
         let mut writer = BufWriter::new(file);
         for _ in 0..size {
             writer.write_all(&[0]).expect("Failed to write");

--- a/below/model/src/collector.rs
+++ b/below/model/src/collector.rs
@@ -15,6 +15,7 @@
 use std::sync::{Arc, Mutex};
 
 use super::*;
+#[cfg(fbcode_build)]
 use crate::collector_plugin;
 use regex::Regex;
 use slog::{self, error};

--- a/below/src/main.rs
+++ b/below/src/main.rs
@@ -831,7 +831,7 @@ fn replay(
 }
 
 fn record(
-    init: init::InitToken,
+    #[allow(unused)] init: init::InitToken,
     logger: slog::Logger,
     errs: Receiver<Error>,
     interval: Duration,
@@ -843,7 +843,7 @@ fn record(
     debug: bool,
     disable_disk_stat: bool,
     disable_exitstats: bool,
-    enable_gpu_stats: bool,
+    #[allow(unused)] enable_gpu_stats: bool,
     compress_opts: &CompressOpts,
 ) -> Result<()> {
     debug!(logger, "Starting up!");

--- a/below/view/src/filter_popup.rs
+++ b/below/view/src/filter_popup.rs
@@ -36,6 +36,7 @@ fn set_cp_filter(c: &mut Cursive, text: Option<String>) {
             crate::process_view::ViewType::cp_filter(c, text)
         }
         MainViewState::Core => crate::core_view::ViewType::cp_filter(c, text),
+        #[cfg(fbcode_build)]
         MainViewState::Gpu => crate::gpu_view::ViewType::cp_filter(c, text),
     }
 }


### PR DESCRIPTION
Summary:
As titled.

Only build warnings left should look like

```
warning: reference to packed field is unaligned
    --> below/btrfs/src/btrfs_api/open_source/btrfs_sys.rs:5152:18
     |
5152 |         unsafe { &(*(::std::ptr::null::<btrfs_inode_item>())).size as *const _ as usize },
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
     = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
     = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
```

which comes from bindgen.

Differential Revision: D36637182

