### PR TITLE
Enable Btrfs stats in live mode

### DIFF
--- a/below/src/main.rs
+++ b/below/src/main.rs
@@ -1076,6 +1076,9 @@ fn live_local(
         model::CollectorOptions {
             cgroup_root: below_config.cgroup_root.clone(),
             exit_data: exit_buffer,
+            enable_btrfs_stats: below_config.enable_btrfs_stats,
+            btrfs_samples: below_config.btrfs_samples,
+            btrfs_min_pct: below_config.btrfs_min_pct,
             gpu_stats_receiver,
             ..Default::default()
         },


### PR DESCRIPTION
Summary: As title. Minor improvement to enable collection in live mode

Differential Revision: D37215383

