### PR TITLE
Allow to build without vendored libraries

### DIFF
--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -47,3 +47,4 @@ libbpf-cargo = "0.13.1"
 
 [features]
 enable_backtrace = []
+no-vendor = ["libbpf-cargo/novendor", "libbpf-rs/novendor", "store/no-vendor"]

--- a/below/store/Cargo.toml
+++ b/below/store/Cargo.toml
@@ -32,3 +32,6 @@ paste = "1.0"
 slog-term = "2.8"
 tempdir = "0.3"
 zstd = "0.11.1+zstd.1.5.2"
+
+[features]
+no-vendor = ["zstd/pkg-config", "zstd-safe/pkg-config"]


### PR DESCRIPTION
Linux distributions don't like bundling dependencies, for good reasons. This commit adds a new feature flag "no-vendor" which disables using vendored libbpf and libzstd (i.e. the binary is linked with the system-provided libraries) when enabled.