### PR TITLE
Disable unused cursive feature termion-backend

### DIFF
--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "3.2.17", features = ["derive", "env", "regex", "unicode", "w
 clap_complete = "3.0.4"
 common = { package = "below-common", version = "0.6.2", path = "common" }
 config = { package = "below-config", version = "0.6.2", path = "config" }
-cursive = { version = "0.19.0", features = ["crossterm-backend", "termion-backend"], default-features = false }
+cursive = { version = "0.19.0", features = ["crossterm-backend"], default-features = false }
 dump = { package = "below-dump", version = "0.6.2", path = "dump" }
 futures = { version = "0.3.22", features = ["async-await", "compat"] }
 indicatif = { version = "0.17.1", features = ["improved_unicode", "rayon", "tokio"] }

--- a/below/common/Cargo.toml
+++ b/below/common/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.65"
 chrono = { version = "0.4", features = ["clock", "serde", "std"], default-features = false }
-cursive = { version = "0.19.0", features = ["crossterm-backend", "termion-backend"], default-features = false }
+cursive = { version = "0.19.0", features = ["crossterm-backend"], default-features = false }
 humantime = "2.1"
 once_cell = "1.12"
 regex = "1.5.4"

--- a/below/view/Cargo.toml
+++ b/below/view/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.65"
 chrono = { version = "0.4", features = ["clock", "serde", "std"], default-features = false }
 common = { package = "below-common", version = "0.6.2", path = "../common" }
 crossterm = { version = "0.23.1", features = ["event-stream"] }
-cursive = { version = "0.19.0", features = ["crossterm-backend", "termion-backend"], default-features = false }
+cursive = { version = "0.19.0", features = ["crossterm-backend"], default-features = false }
 cursive_buffered_backend = "0.6.0"
 humantime = "2.1"
 itertools = "0.10.3"

--- a/below/view/src/lib.rs
+++ b/below/view/src/lib.rs
@@ -304,9 +304,9 @@ impl ViewState {
 impl View {
     pub fn new_with_advance(model: model::Model, mode: ViewMode) -> View {
         let mut inner = cursive::CursiveRunnable::new(|| {
-            let backend = cursive::backends::crossterm::Backend::init().map(|termion_backend| {
+            let backend = cursive::backends::crossterm::Backend::init().map(|backend| {
                 Box::new(cursive_buffered_backend::BufferedBackend::new(
-                    termion_backend,
+                    backend,
                 )) as Box<(dyn cursive::backend::Backend)>
             });
             execute!(std::io::stdout(), DisableMouseCapture).expect("Failed to disable mouse.");


### PR DESCRIPTION
### Fix confusing variable name termion_backend

It's not termion backend, but crossterm backend.

### Disable unused cursive feature termion-backend

Only crossterm backend is used in the code and there's probably no reason for using both.