### PR TITLE
Disable unused/unnecessary regex features

### DIFF
--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -27,7 +27,7 @@ model = { package = "below-model", version = "0.6.2", path = "model" }
 once_cell = "1.12"
 plain = "0.2"
 procfs = { package = "fb_procfs", version = "0.6.2", path = "procfs" }
-regex = "1.5.4"
+regex = { version = "1.5.4", default-features = false, features = ["std", "unicode-perl"] }
 serde_json = { version = "1.0.79", features = ["float_roundtrip", "unbounded_depth"] }
 signal-hook = "0.3"
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }

--- a/below/common/Cargo.toml
+++ b/below/common/Cargo.toml
@@ -15,7 +15,7 @@ chrono = { version = "0.4", features = ["clock", "serde", "std"], default-featur
 cursive = { version = "0.19.0", features = ["crossterm-backend", "termion-backend"], default-features = false }
 humantime = "2.1"
 once_cell = "1.12"
-regex = "1.5.4"
+regex = { version = "1.5.4", default-features = false, features = ["std", "unicode-perl"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
 slog-term = "2.8"
 walkdir = "2.3"

--- a/below/dump/Cargo.toml
+++ b/below/dump/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "3.2.17", features = ["derive", "env", "regex", "unicode", "w
 common = { package = "below-common", version = "0.6.2", path = "../common" }
 model = { package = "below-model", version = "0.6.2", path = "../model" }
 once_cell = "1.12"
-regex = "1.5.4"
+regex = { version = "1.5.4", default-features = false, features = ["std", "unicode-perl"] }
 render = { package = "below-render", version = "0.6.2", path = "../render" }
 serde_json = { version = "1.0.79", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }

--- a/below/model/Cargo.toml
+++ b/below/model/Cargo.toml
@@ -21,7 +21,7 @@ gpu-stats = { package = "below-gpu-stats", version = "0.6.2", path = "../gpu_sta
 hostname = "0.3"
 os_info = "3.0.7"
 procfs = { package = "fb_procfs", version = "0.6.2", path = "../procfs" }
-regex = "1.5.4"
+regex = { version = "1.5.4", default-features = false }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }


### PR DESCRIPTION
To reduce the binary size. It won't have any effect right now because some dependencies pull all regex features, but this will change after updating them to newer versions.