### PR TITLE
Update view lib to properly handle result

### DIFF
--- a/below/view/src/lib.rs
+++ b/below/view/src/lib.rs
@@ -225,7 +225,8 @@ pub fn set_active_screen(c: &mut Cursive, name: &str) {
                 .get_mut()
                 .screen_mut()
                 .unwrap()
-                .take_focus(cursive::direction::Direction::none());
+                .take_focus(cursive::direction::Direction::none())
+                .ok();
         },
     )
     .expect("failed to find main_view_screens");


### PR DESCRIPTION
This should fix the warning mentioned in  [8168](https://github.com/facebookincubator/below/issues/8168). See discussion in Gentoo [28643](https://github.com/gentoo/gentoo/pull/28643) for more details.

Signed-off-by: Daniel Hodges <hodges.daniel.scott@gmail.com>