### PR TITLE
Run tests inside each project independently.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,4 @@ jobs:
     - name: Run tests
       # Skip tests that require host to have cgroup2
       run: >
-        docker run below
-        /root/.cargo/bin/cargo test
-        --release
-        --
-        --skip test_dump
-        --skip advance_forward_and_reverse
-        --skip disable_disk_stat
-        --skip disable_io_stat
-        --skip record_replay_integration
-        --skip test_belowrc_to_event
-        --skip test_event_controller_override
-        --skip test_event_controller_override_failed
-        --skip test_viewrc_collapse_cgroups
-        --skip test_viewrc_default_view
+        docker run below scripts/test_all.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /rustup.sh
 RUN chmod +x /rustup.sh
 RUN bash /rustup.sh -y
 
+ENV PATH=$PATH:/root/.cargo/bin
+
 ADD . /below
 # Build below
 WORKDIR below

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Script to test all crates recursively. Must be run from root of
+# repository.
+
+set -e
+
+for cargo_dir in $(find . -name Cargo.toml -printf '%h\n'); do
+  echo "Running tests in: $cargo_dir"
+  pushd "$cargo_dir"
+  cargo clean
+  cargo test \
+    --release \
+    -- \
+    --skip test_dump \
+    --skip advance_forward_and_reverse \
+    --skip disable_disk_stat \
+    --skip disable_io_stat \
+    --skip record_replay_integration \
+    --skip test_belowrc_to_event \
+    --skip test_event_controller_override \
+    --skip test_event_controller_override_failed \
+    --skip test_viewrc_collapse_cgroups \
+    --skip test_viewrc_default_view
+  popd
+done


### PR DESCRIPTION
We've had issues where CI did not catch a test breakage, e.g. from 0b24b4cd235ab8032a850498fd87d9673b01884f

cargo test --all isn't exactly the same as testing the individual nested projects. For example, if we remove all default features from the `regex` dep in below-common it will fail when you test with working on the project independently. However if you run cargo test on the top level project, it will pass because other nested projects also use `regex` but do include the default features.