### PR TITLE
[WIP] Make controller tests pass

### DIFF
--- a/below/view/src/controllers/test.rs
+++ b/below/view/src/controllers/test.rs
@@ -91,7 +91,7 @@ url = 'n'
     );
     assert_eq!(
         event_controllers.get(&Event::Char('u')),
-        Some(&Controllers::Filter)
+        Some(&Controllers::Url)
     );
     assert_eq!(
         event_controllers.get(&Event::Char('v')),
@@ -151,7 +151,7 @@ url = 'n'
     );
     assert_eq!(
         event_controllers.get(&Event::Char('n')),
-        Some(&Controllers::Url)
+        None
     );
 }
 


### PR DESCRIPTION
For some reason 'u' gets mapped to Url instead of Filter as the command string specifies, and 'n' is not mapped

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>