### PR TITLE
Add build_deb.sh script to build a .deb package 

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,41 @@
+ARG RELEASE=18.04
+FROM ubuntu:${RELEASE} AS build
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  libelf-dev \
+  libncursesw5-dev \
+  libssl-dev \
+  m4 \
+  pkg-config \
+  python3 \
+  zlib1g-dev
+
+WORKDIR /
+
+# Install rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /rustup.sh
+RUN chmod +x /rustup.sh
+RUN bash /rustup.sh -y
+
+# Install cargo-deb to do packaging
+RUN /root/.cargo/bin/cargo install cargo-deb
+
+# Install newer LLVM
+RUN apt-get install -y software-properties-common wget
+RUN echo | add-apt-repository ppa:ubuntu-toolchain-r/test      && \
+  wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh            && \
+  chmod +x /tmp/llvm.sh                                        && \
+  /tmp/llvm.sh 14
+
+# Add new llvm to $PATH
+ENV PATH="$PATH:/usr/lib/llvm-14/bin"
+
+ADD . /below
+# Build below
+WORKDIR below/below
+RUN /root/.cargo/bin/cargo deb

--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -48,3 +48,7 @@ libbpf-cargo = "0.13.1"
 [features]
 enable_backtrace = []
 no-vendor = ["libbpf-cargo/novendor", "libbpf-rs/novendor", "store/no-vendor"]
+
+[package.metadata.deb]
+depends = "libelf1, libncursesw5, zlib1g"
+systemd-units = { unit-name = "below", unit-scripts = "../etc" }

--- a/etc/below.service
+++ b/etc/below.service
@@ -3,7 +3,7 @@ Description=below system monitor recording daemon
 After=time-sync.target
 
 [Service]
-ExecStart=/bin/below record --retain-for-s 604800 --compress
+ExecStart=/usr/bin/below record --retain-for-s 604800 --compress
 # Enable backtraces in errors
 Environment=RUST_LIB_BACKTRACE=1
 Restart=always

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# This script spits out an ubuntu .deb package for below.
+#
+# For example, to build a .deb for ubuntu 18.04:
+#
+#     ./build_deb.sh 18.04
+
+set -eu
+
+# cd to project root
+cd "$(dirname "$(realpath "$0")")"/..
+
+if [[ $# != 1 ]]; then
+  echo "usage: ./build_deb.sh RELEASE" 1>&2
+  exit 1
+fi
+
+docker build -f Dockerfile.debian --build-arg RELEASE="$1" -t below-deb .
+docker run -v $(pwd):/output below-deb /bin/bash -c "cp /below/target/debian/below_*.deb /output"
+
+echo Debian package copied to $(pwd)


### PR DESCRIPTION
This script is helpful for ubuntu packaging.

In the future this could be hooked up to CI to automatically generate
.deb artifacts on release.