### PR TITLE
snapshot: Support specifying snapshot output file

### DIFF
--- a/below/src/main.rs
+++ b/below/src/main.rs
@@ -1456,7 +1456,7 @@ fn snapshot(
         .with_context(|| format!("Failed to create snapshot file {:?}", &tarball_name))?;
     // Create a new tarball with the snapshot dir name
     let mut tar = TarBuilder::new(file);
-    tar.append_dir_all(tarball_name, snapshot_store_path.as_path())
+    tar.append_dir_all("store", snapshot_store_path.as_path())
         .context("Failed to add snapshot store to tar builder")?;
     tar.finish()
         .context("Failed to build compressed snapshot file.")?;


### PR DESCRIPTION
Previously, the snapshot file was always generated in current working
directory. Sometimes it is useful to specify where the snapshot file
should be place and what name it should have. It saves a couple of
steps, especially when the snapshot is intended to be exported off a
remote machine.