### PR TITLE
scripts: build_deb.sh: Use llvm 16

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -44,10 +44,10 @@ RUN apt-get install -y software-properties-common wget
 RUN echo | add-apt-repository ppa:ubuntu-toolchain-r/test      && \
   wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh            && \
   chmod +x /tmp/llvm.sh                                        && \
-  /tmp/llvm.sh 14
+  /tmp/llvm.sh 16
 
 # Add new llvm to $PATH
-ENV PATH="$PATH:/usr/lib/llvm-14/bin"
+ENV PATH="$PATH:/usr/lib/llvm-16/bin"
 
 ADD . /below
 # Build below

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 #
-# This script spits out an ubuntu .deb package for below.
-#
-# For example, to build a .deb for ubuntu 18.04:
-#
-#     ./build_deb.sh 18.04
-#
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+# This script spits out an ubuntu .deb package for below.
+#
+# For example, to build a .deb for ubuntu 18.04:
+#
+#     ./build_deb.sh 18.04
+#
 
 set -eu
 


### PR DESCRIPTION
Seems that llvm 14 can no longer compile exitstat.bpf.c