### PR TITLE
Add clang-15+ prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,6 @@ of [atop](https://linux.die.net/man/1/atop)'s design and style decisions.
 <img src="https://asciinema.org/a/355506.svg" width="500">
 </a>
 
-## Prerequisite
-
-* `below` requires clang-15+. Make sure it is installed and exported.
-```shell
-export CLANG=clang-15
-```
-
 ## Installing
 
 ### Fedora

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ of [atop](https://linux.die.net/man/1/atop)'s design and style decisions.
 <img src="https://asciinema.org/a/355506.svg" width="500">
 </a>
 
+## Prerequisite
+
+* `below` requires clang-15+. Make sure it is installed and exported.
+```shell
+export CLANG=clang-15
+```
+
 ## Installing
 
 ### Fedora

--- a/docs/building.md
+++ b/docs/building.md
@@ -5,7 +5,7 @@ Several dependencies need to be installed before we can build.
 * libz (dynamically linked)
 * libelf (dynamically linked)
 * libncursesw (dynamically linked)
-* clang (for building BPF program at build time)
+* clang-15+ (for building BPF program at build time)
 * rustfmt (used by libbpf-cargo for bpf skeleton code generation)
 
 ## Install build dependencies
@@ -26,6 +26,11 @@ rustup component add rustfmt
 ```
 
 # Building
+
+Make sure clang-15 is installed and exported.
+```shell
+export CLANG=clang-15
+```
 
 Below's UI is quite laggy in debug builds. We recommend always building in
 release mode.


### PR DESCRIPTION
Multiple issues (#8112, #8195) have been created related to build errors because the build isn't using `clang-15` or greater.