### PR TITLE
Show per-cpu fields for `system` when `--detail` is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,6 @@ dependencies = [
  "anyhow",
  "below-btrfs",
  "cgroupfs",
- "once_cell",
  "serde",
  "tempdir",
  "toml 0.7.6",

--- a/below/dump/src/command.rs
+++ b/below/dump/src/command.rs
@@ -162,11 +162,8 @@ impl AggField<SystemModelFieldId> for SystemAggField {
 
         if detail {
             match self {
-                Self::Cpu => enum_iterator::all::<Cpu>()
-                    // The Idx field is always -1 (we aggregate all CPUs)
-                    .filter(|v| v != &Cpu::Idx)
-                    .map(FieldId::Cpu)
-                    .collect(),
+                // If detail is set, per cpu fields are added in `System::dump_model()`.
+                Self::Cpu => vec![],
                 Self::Mem => enum_iterator::all::<Mem>().map(FieldId::Mem).collect(),
                 Self::Vm => enum_iterator::all::<Vm>().map(FieldId::Vm).collect(),
                 Self::Stat => enum_iterator::all::<Stat>().map(FieldId::Stat).collect(),

--- a/below/dump/src/command.rs
+++ b/below/dump/src/command.rs
@@ -162,8 +162,11 @@ impl AggField<SystemModelFieldId> for SystemAggField {
 
         if detail {
             match self {
-                // If detail is set, per cpu fields are added in `System::dump_model()`.
-                Self::Cpu => vec![],
+                Self::Cpu => enum_iterator::all::<Cpu>()
+                    // The Idx field is always -1 (we aggregate all CPUs)
+                    .filter(|v| v != &Cpu::Idx)
+                    .map(FieldId::Cpu)
+                    .collect(),
                 Self::Mem => enum_iterator::all::<Mem>().map(FieldId::Mem).collect(),
                 Self::Vm => enum_iterator::all::<Vm>().map(FieldId::Vm).collect(),
                 Self::Stat => enum_iterator::all::<Stat>().map(FieldId::Stat).collect(),

--- a/below/dump/src/system.rs
+++ b/below/dump/src/system.rs
@@ -43,7 +43,9 @@ impl Dumper for System {
             // If detail is set, add per-cpu fields.
             // The fields need to be added at runtime because we cannot know the number of CPUs in the model statically.
             for key in model.system.cpus.keys() {
-                for subquery_id in &enum_iterator::all::<model::SingleCpuModelFieldId>().collect::<Vec<_>>() {
+                for subquery_id in
+                    &enum_iterator::all::<model::SingleCpuModelFieldId>().collect::<Vec<_>>()
+                {
                     let value = subquery_id.clone();
                     fields.push(DumpField::FieldId(model::SystemModelFieldId::Cpus(
                         model::BTreeMapFieldId {

--- a/below/dump/src/system.rs
+++ b/below/dump/src/system.rs
@@ -37,12 +37,29 @@ impl Dumper for System {
         round: &mut usize,
         comma_flag: bool,
     ) -> Result<IterExecResult> {
+        let mut fields = self.fields.clone();
+
+        if self.opts.detail || self.opts.everything {
+            // If detail is set, add per-cpu fields.
+            for key in model.system.cpus.keys() {
+                for subquery_id in &enum_iterator::all::<model::SingleCpuModelFieldId>().collect::<Vec<_>>() {
+                    let value = subquery_id.clone();
+                    fields.push(DumpField::FieldId(model::SystemModelFieldId::Cpus(
+                        model::BTreeMapFieldId {
+                            key: Some(*key),
+                            subquery_id: value,
+                        },
+                    )));
+                }
+            }
+        }
+
         match self.opts.output_format {
             Some(OutputFormat::Raw) | None => write!(
                 output,
                 "{}",
                 print::dump_raw(
-                    &self.fields,
+                    &fields,
                     ctx,
                     &model.system,
                     *round,
@@ -55,7 +72,7 @@ impl Dumper for System {
                 output,
                 "{}",
                 print::dump_csv(
-                    &self.fields,
+                    &fields,
                     ctx,
                     &model.system,
                     *round,
@@ -67,7 +84,7 @@ impl Dumper for System {
                 output,
                 "{}",
                 print::dump_tsv(
-                    &self.fields,
+                    &fields,
                     ctx,
                     &model.system,
                     *round,
@@ -78,10 +95,10 @@ impl Dumper for System {
             Some(OutputFormat::KeyVal) => write!(
                 output,
                 "{}",
-                print::dump_kv(&self.fields, ctx, &model.system, self.opts.raw)
+                print::dump_kv(&fields, ctx, &model.system, self.opts.raw)
             )?,
             Some(OutputFormat::Json) => {
-                let par = print::dump_json(&self.fields, ctx, &model.system, self.opts.raw);
+                let par = print::dump_json(&fields, ctx, &model.system, self.opts.raw);
                 if comma_flag {
                     write!(output, ",{}", par.to_string())?;
                 } else {
@@ -91,7 +108,7 @@ impl Dumper for System {
             Some(OutputFormat::OpenMetrics) => write!(
                 output,
                 "{}",
-                print::dump_openmetrics(&self.fields, ctx, &model.system)
+                print::dump_openmetrics(&fields, ctx, &model.system)
             )?,
         };
 

--- a/below/dump/src/system.rs
+++ b/below/dump/src/system.rs
@@ -41,6 +41,7 @@ impl Dumper for System {
 
         if self.opts.detail || self.opts.everything {
             // If detail is set, add per-cpu fields.
+            // The fields need to be added at runtime because we cannot know the number of CPUs in the model statically.
             for key in model.system.cpus.keys() {
                 for subquery_id in &enum_iterator::all::<model::SingleCpuModelFieldId>().collect::<Vec<_>>() {
                     let value = subquery_id.clone();


### PR DESCRIPTION
For `--detail` and `--everything`, `below dump system...` shows aggregated view over all the CPUs. The change is to show per-CPU details when queried with `--detail` or `--everything` flag.

Before:
```openmetrics
# TYPE system_cpu_softirq_pct gauge
system_cpu_softirq_pct{cpu="-1",hostname="ip-172-31-24-129"} 0 1696365681
# TYPE system_cpu_softirq_pct gauge
system_cpu_softirq_pct{cpu="-1",hostname="ip-172-31-24-129"} 0 1696365685
```

After:
```openmetrics
# TYPE system_cpus_0_softirq_pct gauge
system_cpus_0_softirq_pct{cpu="0",hostname="ip-172-31-24-129"} 0 1696365580
# TYPE system_cpus_1_softirq_pct gauge
system_cpus_1_softirq_pct{cpu="1",hostname="ip-172-31-24-129"} 0.199203187250996 1696365580
# TYPE system_cpus_0_softirq_pct gauge
system_cpus_0_softirq_pct{cpu="0",hostname="ip-172-31-24-129"} 0 1696365585
# TYPE system_cpus_1_softirq_pct gauge
system_cpus_1_softirq_pct{cpu="1",hostname="ip-172-31-24-129"} 0 1696365585
```