### PR TITLE
Add support for recording `tc` stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "async-trait"
@@ -152,7 +152,7 @@ dependencies = [
  "slog",
  "slog-term",
  "tar",
- "tempdir",
+ "tempfile",
  "users",
 ]
 
@@ -164,7 +164,7 @@ dependencies = [
  "libc",
  "nix 0.25.0",
  "openat",
- "rand 0.8.5",
+ "rand",
  "rand_distr",
  "serde",
  "slog",
@@ -183,7 +183,7 @@ dependencies = [
  "regex",
  "slog",
  "slog-term",
- "tempdir",
+ "tempfile",
  "walkdir",
 ]
 
@@ -195,8 +195,8 @@ dependencies = [
  "below-btrfs",
  "cgroupfs",
  "serde",
- "tempdir",
- "toml 0.7.6",
+ "tempfile",
+ "toml 0.8.5",
 ]
 
 [[package]]
@@ -216,8 +216,8 @@ dependencies = [
  "serde_json",
  "slog",
  "tar",
- "tempdir",
- "toml 0.7.6",
+ "tempfile",
+ "toml 0.8.5",
 ]
 
 [[package]]
@@ -237,6 +237,7 @@ dependencies = [
  "below-btrfs",
  "below-common",
  "below-gpu-stats",
+ "below-tc",
  "below_derive",
  "cgroupfs",
  "enum-iterator",
@@ -279,9 +280,18 @@ dependencies = [
  "slog",
  "slog-term",
  "static_assertions",
- "tempdir",
+ "tempfile",
  "zstd",
  "zstd-safe",
+]
+
+[[package]]
+name = "below-tc"
+version = "0.0.1"
+dependencies = [
+ "netlink-tc",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -304,8 +314,8 @@ dependencies = [
  "once_cell",
  "serde",
  "slog",
- "tempdir",
- "toml 0.7.6",
+ "tempfile",
+ "toml 0.8.5",
 ]
 
 [[package]]
@@ -315,6 +325,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -334,6 +353,12 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -413,7 +438,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -864,12 +889,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fb_procfs"
@@ -902,12 +924,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1138,17 +1154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e481ccbe3dea62107216d0d1138bb8ad8e5e5c43009a098bd1990272c497b0"
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1277,12 +1282,6 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
@@ -1361,6 +1360,69 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "netlink-tc"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88fc45f27284215d439989d7ea3e2c235c0a8f65ebab88d9fcfa60b45c2bb35f"
+dependencies = [
+ "bincode",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-sys",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -1560,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pin-project-lite"
@@ -1600,7 +1662,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1640,26 +1702,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1669,23 +1718,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1703,7 +1737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1728,15 +1762,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1798,15 +1823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rustix"
 version = "0.35.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,24 +1830,10 @@ checksum = "985947f9b6423159c4726323f373be0a21bdb514c5af06a849cb3d2dce2d01e8"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.2.8",
- "io-lifetimes 0.7.4",
+ "io-lifetimes",
  "libc",
  "linux-raw-sys 0.0.46",
  "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.3.1",
- "io-lifetimes 1.0.10",
- "libc",
- "linux-raw-sys 0.3.1",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1949,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -2088,26 +2090,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.11",
- "windows-sys 0.45.0",
+ "rustix 0.38.11",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2240,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "3efaf127c78d5339cc547cce4e4d973bd5e4f56e949a06d091c082ebeef2f800"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2252,18 +2244,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.12"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+checksum = "782bf6c2ddf761c1e7855405e8975472acf76f7f36d0d4328bd3b7a2fae12a85"
 dependencies = [
  "indexmap",
  "serde",
@@ -2463,35 +2455,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2625,9 +2593,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
 dependencies = [
  "memchr",
 ]
@@ -2649,30 +2617,28 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ members = [
   "below/procfs",
   "below/render",
   "below/store",
+  "below/tc",
   "below/view",
 ]

--- a/below/dump/src/lib.rs
+++ b/below/dump/src/lib.rs
@@ -51,6 +51,7 @@ pub mod network;
 pub mod print;
 pub mod process;
 pub mod system;
+pub mod tc;
 pub mod tmain;
 pub mod transport;
 
@@ -115,6 +116,7 @@ pub type NetworkField = DumpField<model::NetworkModelFieldId>;
 pub type IfaceField = DumpField<model::SingleNetModelFieldId>;
 // Essentially the same as NetworkField
 pub type TransportField = DumpField<model::NetworkModelFieldId>;
+pub type TcField = DumpField<model::SingleTcModelFieldId>;
 
 fn get_advance(
     logger: slog::Logger,
@@ -514,6 +516,42 @@ pub fn run(
                 time_begin,
                 time_end,
                 &transport,
+                output.as_mut(),
+                opts.output_format,
+                opts.br,
+                errs,
+            )
+        }
+        DumpCommand::Tc {
+            fields,
+            opts,
+            pattern,
+        } => {
+            let (time_begin, time_end, advance) =
+                get_advance(logger, dir, host, port, snapshot, &opts)?;
+            let detail = opts.everything || opts.detail;
+            let fields = if let Some(pattern_key) = pattern {
+                parse_pattern(filename, pattern_key, "tc")
+            } else {
+                fields
+            };
+            let fields = expand_fields(
+                match fields.as_ref() {
+                    Some(fields) => fields,
+                    _ => command::DEFAULT_TC_FIELDS,
+                },
+                detail,
+            );
+            let tc = tc::Tc::new(&opts, fields);
+            let mut output: Box<dyn Write> = match opts.output.as_ref() {
+                Some(file_path) => Box::new(File::create(file_path)?),
+                None => Box::new(io::stdout()),
+            };
+            dump_timeseries(
+                advance,
+                time_begin,
+                time_end,
+                &tc,
                 output.as_mut(),
                 opts.output_format,
                 opts.br,

--- a/below/dump/src/tc.rs
+++ b/below/dump/src/tc.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+pub struct Tc {
+    opts: GeneralOpt,
+    fields: Vec<TcField>,
+}
+
+impl Tc {
+    pub fn new(opts: &GeneralOpt, fields: Vec<TcField>) -> Self {
+        Self {
+            opts: opts.to_owned(),
+            fields,
+        }
+    }
+}
+
+impl Dumper for Tc {
+    fn dump_model(
+        &self,
+        ctx: &CommonFieldContext,
+        model: &model::Model,
+        output: &mut dyn Write,
+        round: &mut usize,
+        comma_flag: bool,
+    ) -> Result<IterExecResult> {
+        let tcs = model.tc.tc.iter().collect::<Vec<_>>();
+        if tcs.is_empty() {
+            return Ok(IterExecResult::Skip);
+        }
+
+        let mut json_output = json!([]);
+
+        tcs.into_iter()
+            .map(|tc| {
+                match self.opts.output_format {
+                    Some(OutputFormat::Raw) | None => write!(
+                        output,
+                        "{}",
+                        print::dump_raw(
+                            &self.fields,
+                            ctx,
+                            tc,
+                            *round,
+                            self.opts.repeat_title,
+                            self.opts.disable_title,
+                            self.opts.raw
+                        )
+                    )?,
+                    Some(OutputFormat::Csv) => write!(
+                        output,
+                        "{}",
+                        print::dump_csv(
+                            &self.fields,
+                            ctx,
+                            tc,
+                            *round,
+                            self.opts.disable_title,
+                            self.opts.raw
+                        )
+                    )?,
+                    Some(OutputFormat::Tsv) => write!(
+                        output,
+                        "{}",
+                        print::dump_tsv(
+                            &self.fields,
+                            ctx,
+                            tc,
+                            *round,
+                            self.opts.disable_title,
+                            self.opts.raw
+                        )
+                    )?,
+                    Some(OutputFormat::KeyVal) => write!(
+                        output,
+                        "{}",
+                        print::dump_kv(&self.fields, ctx, tc, self.opts.raw)
+                    )?,
+                    Some(OutputFormat::Json) => {
+                        let par = print::dump_json(&self.fields, ctx, tc, self.opts.raw);
+                        json_output.as_array_mut().unwrap().push(par);
+                    }
+                    Some(OutputFormat::OpenMetrics) => {
+                        write!(output, "{}", print::dump_openmetrics(&self.fields, ctx, tc))?
+                    }
+                }
+                *round += 1;
+                Ok(())
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        match (self.opts.output_format, comma_flag) {
+            (Some(OutputFormat::Json), true) => write!(output, ",{}", json_output)?,
+            (Some(OutputFormat::Json), false) => write!(output, "{}", json_output)?,
+            (Some(OutputFormat::OpenMetrics), _) => (),
+            _ => writeln!(output)?,
+        };
+
+        Ok(IterExecResult::Success)
+    }
+}

--- a/below/dump/src/test.rs
+++ b/below/dump/src/test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use command::expand_fields;
 use command::GeneralOpt;
 use command::OutputFormat;
@@ -1061,4 +1063,214 @@ proc = ["datetime", "mem.anon"]
             model::SingleProcessModelFieldId::Mem(model::ProcessMemoryModelFieldId::Anon)
         ))
     );
+}
+
+#[test]
+fn test_tc_titles() {
+    let titles = expand_fields(command::DEFAULT_TC_FIELDS, true)
+        .iter()
+        .filter_map(|dump_field| match dump_field {
+            DumpField::Common(_) => None,
+            DumpField::FieldId(field_id) => Some(field_id.to_string()),
+        })
+        .collect::<Vec<_>>();
+
+    let expected_titles = vec![
+        "dev",
+        "kind",
+        "qlen",
+        "bps",
+        "pps",
+        "bytes_per_sec",
+        "packets_per_sec",
+        "backlog_per_sec",
+        "drops_per_sec",
+        "requeues_per_sec",
+        "overlimits_per_sec",
+        "xstats.fq_codel.maxpacket",
+        "xstats.fq_codel.ecn_mark",
+        "xstats.fq_codel.new_flows_len",
+        "xstats.fq_codel.old_flows_len",
+        "xstats.fq_codel.ce_mark",
+        "xstats.fq_codel.drop_overlimit_per_sec",
+        "xstats.fq_codel.new_flow_count_per_sec",
+        "xstats.fq_codel.memory_usage_per_sec",
+        "xstats.fq_codel.drop_overmemory_per_sec",
+        "qdisc.fq_codel.target",
+        "qdisc.fq_codel.limit",
+        "qdisc.fq_codel.interval",
+        "qdisc.fq_codel.ecn",
+        "qdisc.fq_codel.quantum",
+        "qdisc.fq_codel.ce_threshold",
+        "qdisc.fq_codel.drop_batch_size",
+        "qdisc.fq_codel.memory_limit",
+        "qdisc.fq_codel.flows_per_sec",
+    ];
+    assert_eq!(titles, expected_titles);
+}
+
+#[test]
+fn test_dump_tc_content() {
+    let tc_models = vec![
+        model::SingleTcModel {
+            dev: 1,
+            kind: "mq".to_string(),
+            qlen: Some(42),
+            bps: Some(420),
+            pps: Some(1337),
+            bytes_per_sec: Some(299792458),
+            packets_per_sec: Some(314),
+            backlog_per_sec: Some(271828182),
+            drops_per_sec: Some(8675309),
+            requeues_per_sec: Some(12345),
+            overlimits_per_sec: Some(314159),
+            qdisc: None,
+            xstats: None,
+        },
+        model::SingleTcModel {
+            dev: 1,
+            kind: "fq_codel".to_string(),
+            qlen: Some(42),
+            bps: Some(420),
+            pps: Some(1337),
+            bytes_per_sec: Some(299792458),
+            packets_per_sec: Some(314),
+            backlog_per_sec: Some(271828182),
+            drops_per_sec: Some(8675309),
+            requeues_per_sec: Some(12345),
+            overlimits_per_sec: Some(314159),
+            qdisc: Some(model::QDiscModel {
+                fq_codel: Some(model::FqCodelQDiscModel {
+                    target: 2701,
+                    limit: 7,
+                    interval: 3,
+                    ecn: 6,
+                    quantum: 42,
+                    ce_threshold: 101,
+                    drop_batch_size: 9000,
+                    memory_limit: 123456,
+                    flows_per_sec: Some(31415),
+                }),
+            }),
+            xstats: Some(model::XStatsModel {
+                fq_codel: Some(model::FqCodelXStatsModel {
+                    maxpacket: 8675309,
+                    ecn_mark: 299792458,
+                    new_flows_len: 314,
+                    old_flows_len: 1729,
+                    ce_mark: 42,
+                    drop_overlimit_per_sec: Some(420),
+                    new_flow_count_per_sec: Some(1337),
+                    memory_usage_per_sec: Some(271828182),
+                    drop_overmemory_per_sec: Some(27182),
+                }),
+            }),
+        },
+    ];
+
+    let model = model::Model {
+        time_elapsed: Duration::from_secs(60 * 10),
+        timestamp: SystemTime::now(),
+        system: model::SystemModel::default(),
+        cgroup: model::CgroupModel::default(),
+        process: model::ProcessModel::default(),
+        network: model::NetworkModel::default(),
+        gpu: None,
+        tc: model::TcModel {
+            tc: tc_models,
+        },
+    };
+
+    let mut opts: GeneralOpt = Default::default();
+    let fields = command::expand_fields(command::DEFAULT_TC_FIELDS, true);
+
+    opts.output_format = Some(OutputFormat::Json);
+    let queue_dumper = tc::Tc::new(&opts, fields.clone());
+
+    let mut queue_content: Vec<u8> = Vec::new();
+    let mut round = 0;
+    let ctx = CommonFieldContext {
+        timestamp: 0,
+        hostname: "h".to_string(),
+    };
+
+    let result = queue_dumper
+        .dump_model(&ctx, &model, &mut queue_content, &mut round, false)
+        .expect("Failed to dump queue model");
+    assert!(result == tmain::IterExecResult::Success);
+
+    // verify json correctness
+    assert!(!queue_content.is_empty());
+    let jval: Value =
+        serde_json::from_slice(&queue_content).expect("Fail parse json of queue dump");
+
+    let expected_json = json!([
+        {
+            "Datetime": "1970-01-01 00:00:00",
+            "Device": "1",
+            "Kind": "mq",
+            "Queue Length": "42",
+            "Bps": "420 B/s",
+            "Pps": "1337/s",
+            "Bytes": "285.9 MB/s",
+            "Packets": "314/s",
+            "Backlog": "271828182/s",
+            "Drops": "8675309/s",
+            "Requeues": "12345/s",
+            "Overlimits": "314159/s",
+            "Target": "?",
+            "Limit": "?",
+            "Interval": "?",
+            "Ecn": "?",
+            "Quantum": "?",
+            "CeThreshold": "?",
+            "DropBatchSize": "?",
+            "MemoryLimit": "?",
+            "Flows": "?",
+            "MaxPacket": "?",
+            "EcnMark": "?",
+            "NewFlowsLen": "?",
+            "OldFlowsLen": "?",
+            "CeMark": "?",
+            "DropOverlimit": "?",
+            "NewFlowCount": "?",
+            "MemoryUsage": "?",
+            "DropOvermemory": "?",
+            "Timestamp": "0"
+        },
+        {
+            "Datetime": "1970-01-01 00:00:00",
+            "Device": "1",
+            "Kind": "fq_codel",
+            "Queue Length": "42",
+            "Bps": "420 B/s",
+            "Pps": "1337/s",
+            "Bytes": "285.9 MB/s",
+            "Packets": "314/s",
+            "Backlog": "271828182/s",
+            "Drops": "8675309/s",
+            "Requeues": "12345/s",
+            "Overlimits": "314159/s",
+            "Target": "2701",
+            "Limit": "7",
+            "Interval": "3",
+            "Ecn": "6",
+            "Quantum": "42",
+            "CeThreshold": "101",
+            "DropBatchSize": "9000",
+            "MemoryLimit": "123456",
+            "Flows": "31415/s",
+            "MaxPacket": "8675309",
+            "EcnMark": "299792458",
+            "NewFlowsLen": "314",
+            "OldFlowsLen": "1729",
+            "CeMark": "42",
+            "DropOverlimit": "420/s",
+            "NewFlowCount": "1337/s",
+            "MemoryUsage": "271828182/s",
+            "DropOvermemory": "27182/s",
+            "Timestamp": "0"
+        }
+    ]);
+    assert_eq!(jval, expected_json);
 }

--- a/below/model/Cargo.toml
+++ b/below/model/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1.9.2"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
+tc = { package = "below-tc", version = "0.0.1", path = "../tc" }
 
 [dev-dependencies]
 futures = { version = "0.3.28", features = ["async-await", "compat"] }

--- a/below/model/src/collector.rs
+++ b/below/model/src/collector.rs
@@ -273,6 +273,15 @@ fn collect_sample(logger: &slog::Logger, options: &CollectorOptions) -> Result<S
                 None
             }
         },
+        tc: {
+            match tc::tc_stats() {
+                Ok(tc_stats) => tc_stats,
+                Err(e) => {
+                    error!(logger, "{:#}", e);
+                    Default::default()
+                }
+            }
+        },
     })
 }
 
@@ -423,6 +432,13 @@ macro_rules! usec_pct {
 }
 
 macro_rules! count_per_sec {
+    ($a:ident, $b:ident, $delta:expr, $target_type:ty) => {{
+        let mut ret = None;
+        if $a <= $b {
+            ret = Some((($b - $a) as f64 / $delta.as_secs_f64()).ceil() as $target_type);
+        }
+        ret
+    }};
     ($a_opt:expr, $b_opt:expr, $delta:expr) => {{
         let mut ret = None;
         if let (Some(a), Some(b)) = ($a_opt, $b_opt) {

--- a/below/model/src/common_field_ids.rs
+++ b/below/model/src/common_field_ids.rs
@@ -23,7 +23,7 @@
 ///
 /// This list also servers as documentation for available field ids that could
 /// be used in other below crates. A test ensures that this list is up-to-date.
-pub const COMMON_MODEL_FIELD_IDS: [&str; 362] = [
+pub const COMMON_MODEL_FIELD_IDS: [&str; 391] = [
     "system.hostname",
     "system.kernel_version",
     "system.os_release",
@@ -386,4 +386,33 @@ pub const COMMON_MODEL_FIELD_IDS: [&str; 362] = [
     "network.udp6.sndbuf_errors",
     "network.udp6.in_csum_errors",
     "network.udp6.ignored_multi",
+    "tc.tc.<idx>.backlog_per_sec",
+    "tc.tc.<idx>.bps",
+    "tc.tc.<idx>.bytes_per_sec",
+    "tc.tc.<idx>.dev",
+    "tc.tc.<idx>.drops_per_sec",
+    "tc.tc.<idx>.kind",
+    "tc.tc.<idx>.overlimits_per_sec",
+    "tc.tc.<idx>.packets_per_sec",
+    "tc.tc.<idx>.pps",
+    "tc.tc.<idx>.qdisc.fq_codel.ce_threshold",
+    "tc.tc.<idx>.qdisc.fq_codel.drop_batch_size",
+    "tc.tc.<idx>.qdisc.fq_codel.ecn",
+    "tc.tc.<idx>.qdisc.fq_codel.flows_per_sec",
+    "tc.tc.<idx>.qdisc.fq_codel.interval",
+    "tc.tc.<idx>.qdisc.fq_codel.limit",
+    "tc.tc.<idx>.qdisc.fq_codel.memory_limit",
+    "tc.tc.<idx>.qdisc.fq_codel.quantum",
+    "tc.tc.<idx>.qdisc.fq_codel.target",
+    "tc.tc.<idx>.qlen",
+    "tc.tc.<idx>.requeues_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.ce_mark",
+    "tc.tc.<idx>.xstats.fq_codel.drop_overlimit_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.drop_overmemory_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.ecn_mark",
+    "tc.tc.<idx>.xstats.fq_codel.maxpacket",
+    "tc.tc.<idx>.xstats.fq_codel.memory_usage_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.new_flow_count_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.new_flows_len",
+    "tc.tc.<idx>.xstats.fq_codel.old_flows_len",
 ];

--- a/below/model/src/lib.rs
+++ b/below/model/src/lib.rs
@@ -39,6 +39,7 @@ pub mod process;
 pub mod sample;
 mod sample_model;
 pub mod system;
+pub mod tc_model;
 
 open_source_shim!(pub);
 
@@ -48,6 +49,7 @@ pub use network::*;
 pub use process::*;
 pub use sample::*;
 pub use system::*;
+pub use tc_model::*;
 
 /// A wrapper for different field types used in Models. By this way we can query
 /// different fields in a single function without using Box.
@@ -494,6 +496,8 @@ pub struct Model {
     pub network: NetworkModel,
     #[queriable(subquery)]
     pub gpu: Option<GpuModel>,
+    #[queriable(subquery)]
+    pub tc: TcModel,
 }
 
 impl Model {
@@ -524,6 +528,7 @@ impl Model {
                     }
                 })
             }),
+            tc: TcModel::new(&sample.tc, last.map(|(s, d)| (&s.tc, d))),
         }
     }
 }

--- a/below/model/src/sample.rs
+++ b/below/model/src/sample.rs
@@ -21,6 +21,7 @@ pub struct Sample {
     pub system: SystemSample,
     pub netstats: procfs::NetStat,
     pub gpus: Option<gpu_stats::GpuSample>,
+    pub tc: tc::TcStats,
 }
 
 #[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]

--- a/below/model/src/sample_model.rs
+++ b/below/model/src/sample_model.rs
@@ -840,6 +840,49 @@ pub const SAMPLE_MODEL_JSON: &str = r#"
             "in_csum_errors": 0,
             "ignored_multi": 0
         }
-    }
+    },
+    "tc": {
+        "tc": [
+          {
+            "dev": 1729,
+            "kind": "fq_codel",
+            "qlen": 42,
+            "bps": 420,
+            "pps": 1337,
+            "bytes_per_sec": 299792458,
+            "packets_per_sec": 314,
+            "backlog_per_sec": 2718281828,
+            "drops_per_sec": 8675309,
+            "requeues_per_sec": 12345,
+            "overlimits_per_sec": 314159,
+            "qdisc": {
+              "fq_codel": {
+                "target": 2701,
+                "limit": 7,
+                "interval": 3,
+                "ecn": 6,
+                "quantum": 42,
+                "ce_threshold": 101,
+                "drop_batch_size": 9000,
+                "memory_limit": 123456,
+                "flows_per_sec": 31415
+              }
+            },
+            "xstats": {
+              "fq_codel": {
+                "maxpacket": 8675309,
+                "ecn_mark": 299792458,
+                "new_flows_len": 314,
+                "old_flows_len": 1729,
+                "ce_mark": 42,
+                "drop_overlimit_per_sec": 420,
+                "new_flow_count_per_sec": 1337,
+                "memory_usage_per_sec": 2718281828,
+                "drop_overmemory_per_sec": 27182
+              }
+            }
+          }
+        ]
+      }
 }
 "#;

--- a/below/model/src/tc_model.rs
+++ b/below/model/src/tc_model.rs
@@ -1,0 +1,271 @@
+use super::*;
+
+use tc::{QDisc, Tc, XStats};
+
+macro_rules! rate {
+    ($field:ident, $sample:ident, $last:ident, $target_type:ty) => {
+        $last.and_then(|(l, d)| {
+            let s = $sample.$field;
+            let l = l.$field;
+            count_per_sec!(s, l, d, $target_type)
+        })
+    };
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct TcModel {
+    #[queriable(subquery)]
+    pub tc: Vec<SingleTcModel>,
+}
+
+impl TcModel {
+    pub fn new(
+        sample: &BTreeMap<u32, Vec<Tc>>,
+        last: Option<(&BTreeMap<u32, Vec<Tc>>, Duration)>,
+    ) -> Self {
+        let tc = sample
+            .iter()
+            .flat_map(|(dev, tcs)| {
+                tcs.iter().enumerate().map(|(seq, tc)| {
+                    SingleTcModel::new(
+                        tc,
+                        last.and_then(|(last, d)| {
+                            last.get(dev).and_then(|tcs| tcs.get(seq)).map(|tc| (tc, d))
+                        }),
+                        *dev,
+                    )
+                })
+            })
+            .collect();
+
+        Self { tc }
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct SingleTcModel {
+    /// Index for identifying the interface
+    pub dev: u32,
+    /// Name of the qdisc or class
+    pub kind: String,
+
+    pub qlen: Option<u32>,
+    pub bps: Option<u32>,
+    pub pps: Option<u32>,
+
+    pub bytes_per_sec: Option<u64>,
+    pub packets_per_sec: Option<u32>,
+    pub backlog_per_sec: Option<u32>,
+    pub drops_per_sec: Option<u32>,
+    pub requeues_per_sec: Option<u32>,
+    pub overlimits_per_sec: Option<u32>,
+
+    #[queriable(subquery)]
+    pub qdisc: Option<QDiscModel>,
+
+    #[queriable(subquery)]
+    pub xstats: Option<XStatsModel>,
+}
+
+impl Nameable for SingleTcModel {
+    fn name() -> &'static str {
+        "tc"
+    }
+}
+
+impl SingleTcModel {
+    pub fn new(sample: &tc::Tc, last: Option<(&tc::Tc, Duration)>, dev: u32) -> Self {
+        let mut tc_model = SingleTcModel {
+            dev,
+            kind: sample.kind.clone(),
+            ..Default::default()
+        };
+
+        let stats = &sample.stats;
+        tc_model.qlen = stats.qlen;
+        tc_model.bps = stats.bps;
+        tc_model.pps = stats.pps;
+
+        last.map(|(l, d)| {
+            let last = &l.stats;
+            tc_model.bytes_per_sec = count_per_sec!(stats.bytes, last.bytes, d, u64);
+            tc_model.packets_per_sec = count_per_sec!(stats.packets, last.packets, d, u32);
+            tc_model.backlog_per_sec = count_per_sec!(stats.backlog, last.backlog, d, u32);
+            tc_model.drops_per_sec = count_per_sec!(stats.drops, last.drops, d, u32);
+            tc_model.requeues_per_sec = count_per_sec!(stats.requeues, last.requeues, d, u32);
+            tc_model.overlimits_per_sec = count_per_sec!(stats.overlimits, last.overlimits, d, u32);
+        });
+
+        if let Some(sample) = stats.xstats.as_ref() {
+            let last =
+                last.and_then(|(last, d)| last.stats.xstats.as_ref().map(|l| (l, d)));
+
+            tc_model.xstats = Some(XStatsModel::new(sample, last));
+        }
+
+        if let Some(sample) = sample.qdisc.as_ref() {
+            let last = last.and_then(|(last, d)| last.qdisc.as_ref().map(|l| (l, d)));
+
+            tc_model.qdisc = Some(QDiscModel::new(sample, last));
+        }
+
+        tc_model
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct QDiscModel {
+    #[queriable(subquery)]
+    pub fq_codel: Option<FqCodelQDiscModel>,
+}
+
+impl QDiscModel {
+    fn new(sample: &tc::QDisc, last: Option<(&tc::QDisc, Duration)>) -> Self {
+        match sample {
+            QDisc::FqCodel(sample) => Self {
+                fq_codel: {
+                    last.map(|(l, d)| match l {
+                        QDisc::FqCodel(last) => {
+                            let last = Some((last, d));
+                            FqCodelQDiscModel::new(sample, last)
+                        }
+                    })
+                },
+            },
+        }
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct FqCodelQDiscModel {
+    pub target: u32,
+    pub limit: u32,
+    pub interval: u32,
+    pub ecn: u32,
+    pub quantum: u32,
+    pub ce_threshold: u32,
+    pub drop_batch_size: u32,
+    pub memory_limit: u32,
+    pub flows_per_sec: Option<u32>,
+}
+
+impl FqCodelQDiscModel {
+    fn new(sample: &tc::FqCodelQDisc, last: Option<(&tc::FqCodelQDisc, Duration)>) -> Self {
+        Self {
+            target: sample.target,
+            limit: sample.limit,
+            interval: sample.interval,
+            ecn: sample.ecn,
+            quantum: sample.quantum,
+            ce_threshold: sample.ce_threshold,
+            drop_batch_size: sample.drop_batch_size,
+            memory_limit: sample.memory_limit,
+            flows_per_sec: {
+                last.and_then(|(l, d)| {
+                    let last = Some((l, d));
+                    rate!(flows, sample, last, u32)
+                })
+            },
+        }
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct XStatsModel {
+    #[queriable(subquery)]
+    pub fq_codel: Option<FqCodelXStatsModel>,
+}
+
+impl XStatsModel {
+    fn new(sample: &tc::XStats, last: Option<(&tc::XStats, Duration)>) -> Self {
+        match sample {
+            XStats::FqCodel(sample) => Self {
+                fq_codel: {
+                    last.map(|(l, d)| match l {
+                        XStats::FqCodel(last) => {
+                            let last = Some((last, d));
+                            FqCodelXStatsModel::new(sample, last)
+                        }
+                    })
+                },
+            },
+        }
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct FqCodelXStatsModel {
+    pub maxpacket: u32,
+    pub ecn_mark: u32,
+    pub new_flows_len: u32,
+    pub old_flows_len: u32,
+    pub ce_mark: u32,
+    pub drop_overlimit_per_sec: Option<u32>,
+    pub new_flow_count_per_sec: Option<u32>,
+    pub memory_usage_per_sec: Option<u32>,
+    pub drop_overmemory_per_sec: Option<u32>,
+}
+
+impl FqCodelXStatsModel {
+    fn new(sample: &tc::FqCodelXStats, last: Option<(&tc::FqCodelXStats, Duration)>) -> Self {
+        Self {
+            maxpacket: sample.maxpacket,
+            ecn_mark: sample.ecn_mark,
+            new_flows_len: sample.new_flows_len,
+            old_flows_len: sample.old_flows_len,
+            ce_mark: sample.ce_mark,
+            drop_overlimit_per_sec: rate!(drop_overlimit, sample, last, u32),
+            new_flow_count_per_sec: rate!(drop_overlimit, sample, last, u32),
+            memory_usage_per_sec: rate!(drop_overlimit, sample, last, u32),
+            drop_overmemory_per_sec: rate!(drop_overlimit, sample, last, u32),
+        }
+    }
+}

--- a/below/render/src/default_configs.rs
+++ b/below/render/src/default_configs.rs
@@ -1417,3 +1417,183 @@ impl HasRenderConfig for model::CgroupProperties {
         }
     }
 }
+
+impl HasRenderConfig for model::SingleTcModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::SingleTcModelFieldId::*;
+        let rc = RenderConfigBuilder::new();
+        match field_id {
+            Dev => rc.title("Device"),
+            Kind => rc.title("Kind"),
+            Qlen => rc.title("Queue Length"),
+            Bps => rc.title("Bps").format(ReadableSize).suffix("/s"),
+            Pps => rc.title("Pps").suffix("/s"),
+            BytesPerSec => rc.title("Bytes").format(ReadableSize).suffix("/s"),
+            PacketsPerSec => rc.title("Packets").suffix("/s"),
+            BacklogPerSec => rc.title("Backlog").suffix("/s"),
+            DropsPerSec => rc.title("Drops").suffix("/s"),
+            RequeuesPerSec => rc.title("Requeues").suffix("/s"),
+            OverlimitsPerSec => rc.title("Overlimits").suffix("/s"),
+            Qdisc(field_id) => model::QDiscModel::get_render_config_builder(field_id),
+            Xstats(field_id) => model::XStatsModel::get_render_config_builder(field_id),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::SingleTcModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::SingleTcModelFieldId::*;
+        let gauge = gauge()
+            .label("device", &self.dev.to_string())
+            .label("qdisc", &self.kind);
+        match field_id {
+            Dev => None,
+            Kind => None,
+            Qlen => Some(gauge),
+            Bps => Some(gauge.unit("bytes_per_second")),
+            Pps => Some(gauge.unit("packets_per_second")),
+            BytesPerSec => Some(gauge.unit("bytes_per_second")),
+            PacketsPerSec => Some(gauge.unit("packets_per_second")),
+            BacklogPerSec => Some(gauge.unit("packets_per_second")),
+            DropsPerSec => Some(gauge.unit("packets_per_second")),
+            RequeuesPerSec => Some(gauge.unit("packets_per_second")),
+            OverlimitsPerSec => Some(gauge.unit("packets_per_second")),
+            Qdisc(field_id) => self
+                .qdisc
+                .as_ref()
+                .and_then(|qdisc| qdisc.get_openmetrics_config_for_dump(field_id)),
+            Xstats(field_id) => self
+                .xstats
+                .as_ref()
+                .and_then(|xstats| xstats.get_openmetrics_config_for_dump(field_id)),
+        }
+    }
+}
+
+impl HasRenderConfig for model::QDiscModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::QDiscModelFieldId::*;
+        match field_id {
+            FqCodel(field_id) => model::FqCodelQDiscModel::get_render_config_builder(field_id),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::QDiscModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::QDiscModelFieldId::*;
+        match field_id {
+            FqCodel(field_id) => self
+                .fq_codel
+                .as_ref()
+                .and_then(|fq_codel| fq_codel.get_openmetrics_config_for_dump(field_id)),
+        }
+    }
+}
+
+impl HasRenderConfig for model::FqCodelQDiscModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::FqCodelQDiscModelFieldId::*;
+        let rc = RenderConfigBuilder::new();
+        match field_id {
+            Target => rc.title("Target"),
+            Limit => rc.title("Limit"),
+            Interval => rc.title("Interval"),
+            Ecn => rc.title("Ecn"),
+            Quantum => rc.title("Quantum"),
+            CeThreshold => rc.title("CeThreshold"),
+            DropBatchSize => rc.title("DropBatchSize"),
+            MemoryLimit => rc.title("MemoryLimit"),
+            FlowsPerSec => rc.title("Flows").suffix("/s"),
+        }
+    }
+}
+
+impl HasRenderConfig for model::XStatsModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::XStatsModelFieldId::*;
+        match field_id {
+            FqCodel(field_id) => model::FqCodelXStatsModel::get_render_config_builder(field_id),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::XStatsModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::XStatsModelFieldId::*;
+        match field_id {
+            FqCodel(field_id) => self
+                .fq_codel
+                .as_ref()
+                .and_then(|fq_codel| fq_codel.get_openmetrics_config_for_dump(field_id)),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::FqCodelQDiscModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::FqCodelQDiscModelFieldId::*;
+        match field_id {
+            Target => Some(gauge()),
+            Limit => Some(gauge()),
+            Interval => Some(gauge()),
+            Ecn => Some(gauge()),
+            Quantum => Some(gauge()),
+            CeThreshold => Some(gauge()),
+            DropBatchSize => Some(gauge()),
+            MemoryLimit => Some(gauge()),
+            FlowsPerSec => Some(gauge()),
+        }
+    }
+}
+
+impl HasRenderConfig for model::FqCodelXStatsModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::FqCodelXStatsModelFieldId::*;
+        let rc = RenderConfigBuilder::new();
+        match field_id {
+            Maxpacket => rc.title("MaxPacket"),
+            EcnMark => rc.title("EcnMark"),
+            NewFlowsLen => rc.title("NewFlowsLen"),
+            OldFlowsLen => rc.title("OldFlowsLen"),
+            CeMark => rc.title("CeMark"),
+            DropOverlimitPerSec => rc.title("DropOverlimit").suffix("/s"),
+            NewFlowCountPerSec => rc.title("NewFlowCount").suffix("/s"),
+            MemoryUsagePerSec => rc.title("MemoryUsage").suffix("/s"),
+            DropOvermemoryPerSec => rc.title("DropOvermemory").suffix("/s"),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::FqCodelXStatsModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::FqCodelXStatsModelFieldId::*;
+        let gauge = gauge();
+        match field_id {
+            Maxpacket => Some(gauge),
+            EcnMark => Some(gauge),
+            NewFlowsLen => Some(gauge),
+            OldFlowsLen => Some(gauge),
+            CeMark => Some(gauge),
+            DropOverlimitPerSec => Some(gauge),
+            NewFlowCountPerSec => Some(gauge),
+            MemoryUsagePerSec => Some(gauge),
+            DropOvermemoryPerSec => Some(gauge),
+        }
+    }
+}

--- a/below/tc/Cargo.toml
+++ b/below/tc/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "below-tc"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+thiserror = "1.0"
+netlink-tc = "0.0.4"
+serde = { version = "1.0", features = ["derive", "rc"] }

--- a/below/tc/src/errors.rs
+++ b/below/tc/src/errors.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TcError {
+    #[error("Failed to read tc stats: {0}")]
+    Read(String),
+}

--- a/below/tc/src/lib.rs
+++ b/below/tc/src/lib.rs
@@ -1,0 +1,30 @@
+mod errors;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use std::collections::BTreeMap;
+
+use netlink_tc as tc;
+
+pub use errors::*;
+pub use types::*;
+
+pub type TcStats = BTreeMap<u32, Vec<Tc>>;
+pub type Result<T> = std::result::Result<T, errors::TcError>;
+
+/// Get list of all `tc` qdiscs and classes.
+pub fn tc_stats() -> Result<TcStats> {
+    read_tc_stats::<tc::Netlink>()
+}
+
+fn read_tc_stats<T: tc::NetlinkConnection>() -> Result<TcStats> {
+    let mut tc_map = BTreeMap::new();
+    let tc_stats = tc::qdiscs::<T>().map_err(|e| TcError::Read(e.to_string()))?;
+    for tc_stat in tc_stats {
+        let tc = Tc::new(&tc_stat);
+        tc_map.entry(tc.index).or_insert_with(Vec::new).push(tc);
+    }
+    Ok(tc_map)
+}

--- a/below/tc/src/test.rs
+++ b/below/tc/src/test.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+struct FakeNetlink;
+
+impl tc::NetlinkConnection for FakeNetlink {
+    fn new() -> std::result::Result<Self, tc::errors::NetlinkError>
+    where
+        Self: Sized {
+        Ok(Self {})
+    }
+
+    fn qdiscs(&self) -> std::result::Result<Vec<tc::TcMsg>, tc::errors::NetlinkError> {
+        Ok(
+            vec![
+                tc::TcMsg {
+                    header: tc::TcHeader {
+                        index: 2,
+                        handle: 0,
+                        parent: 2,
+                    },
+                    attrs: vec![
+                        tc::TcAttr::Kind("fq_codel".to_string()),
+                        tc::TcAttr::Options(vec![
+                            tc::TcOption {
+                                kind: 1,
+                                bytes: vec![135, 19, 0, 0],
+                            },
+                            tc::TcOption {
+                                kind: 2,
+                                bytes: vec![0, 40, 0, 0],
+                            },
+                            tc::TcOption {
+                                kind: 3,
+                                bytes: vec![159, 134, 1, 0],
+                            },
+                            tc::TcOption {
+                                kind: 4,
+                                bytes: vec![1, 0, 0, 0],
+                            },
+                            tc::TcOption {
+                                kind: 6,
+                                bytes: vec![234, 5, 0, 0],
+                            },
+                            tc::TcOption {
+                                kind: 8,
+                                bytes: vec![64, 0, 0, 0],
+                            },
+                            tc::TcOption {
+                                kind: 9,
+                                bytes: vec![0, 0, 0, 2],
+                            },
+                            tc::TcOption {
+                                kind: 5,
+                                bytes: vec![0, 4, 0, 0],
+                            },
+                        ]),
+                        tc::TcAttr::Stats(vec![
+                            76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ]),
+                        tc::TcAttr::Stats2(vec![
+                            tc::TcStats2::StatsBasic(vec![76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0]),
+                            tc::TcStats2::StatsQueue(vec![
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0,
+                            ]),
+                            tc::TcStats2::StatsApp(vec![
+                                0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            ]),
+                        ]),
+                        tc::TcAttr::Xstats(vec![
+                            0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ]),
+                        tc::TcAttr::HwOffload(0),
+                    ],
+                }
+        ])
+    }
+
+    fn classes(&self, _index: i32) -> std::result::Result<Vec<tc::TcMsg>, tc::errors::NetlinkError> {
+        Ok(Vec::new())
+    }
+
+    fn links(&self) -> std::result::Result<Vec<tc::LinkMsg>, tc::errors::NetlinkError> {
+        Ok(Vec::new())
+    }
+}
+
+#[test]
+fn test_tc_stats() {
+    let tc_map = read_tc_stats::<FakeNetlink>().unwrap();
+
+    let tc = tc_map.get(&2).unwrap().get(0).unwrap();
+    assert_eq!(tc.index, 2);
+    assert_eq!(tc.handle, 0);
+    assert_eq!(tc.parent, 2);
+
+    assert_eq!(tc.kind, "fq_codel");
+    assert_eq!(tc.stats.bytes, Some(39902796));
+    assert_eq!(tc.stats.packets, Some(165687));
+    assert_eq!(tc.stats.qlen, Some(0));
+    assert_eq!(tc.stats.bps, Some(0));
+    assert_eq!(tc.stats.pps, Some(0));
+
+    assert!(tc.qdisc.is_some());
+    assert!(tc.stats.xstats.is_some());
+}

--- a/below/tc/src/types.rs
+++ b/below/tc/src/types.rs
@@ -1,0 +1,163 @@
+use super::*;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Tc {
+    pub index: u32,
+    pub handle: u32,
+    pub parent: u32,
+    pub kind: String,
+    pub stats: Stats,
+    pub qdisc: Option<QDisc>,
+}
+
+impl Tc {
+    pub fn new(tc: &tc::Tc) -> Self {
+        let tc_stats = tc.attr.stats.as_ref();
+        let tc_stats2 = tc.attr.stats2.as_ref();
+        let bps = tc_stats.map(|stats| stats.bps);
+        let pps = tc_stats.map(|stats| stats.pps);
+
+        let mut stats = Stats {
+            bps,
+            pps,
+            ..Default::default()
+        };
+        if let Some(basic) = tc_stats2.and_then(|s| s.basic.as_ref()) {
+            stats.bytes = Some(basic.bytes);
+            stats.packets = Some(basic.packets);
+        }
+
+        if let Some(queue) = tc_stats2.and_then(|s| s.queue.as_ref()) {
+            stats.qlen = Some(queue.qlen);
+            stats.backlog = Some(queue.backlog);
+            stats.drops = Some(queue.drops);
+            stats.requeues = Some(queue.requeues);
+            stats.overlimits = Some(queue.overlimits);
+        }
+
+        stats.xstats = if let Some(xstats) = tc.attr.xstats.as_ref() {
+            match xstats {
+                tc::XStats::FqCodel(fq_codel_xstats) => {
+                    Some(XStats::FqCodel(FqCodelXStats::new(fq_codel_xstats)))
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        let qdisc = if let Some(tc_qdisc) = tc.attr.qdisc.as_ref() {
+            match tc_qdisc {
+                tc::QDisc::FqCodel(fq_codel) => Some(QDisc::FqCodel(FqCodelQDisc::new(fq_codel))),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        Self {
+            index: tc.msg.index,
+            handle: tc.msg.handle,
+            parent: tc.msg.parent,
+            kind: tc.attr.kind.clone(),
+            stats,
+            qdisc,
+        }
+    }
+}
+
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Stats {
+    // Stats2::StatsBasic
+    pub bytes: Option<u64>,
+    pub packets: Option<u32>,
+
+    // Stats2::StatsQueue
+    pub qlen: Option<u32>,
+    pub backlog: Option<u32>,
+    pub drops: Option<u32>,
+    pub requeues: Option<u32>,
+    pub overlimits: Option<u32>,
+
+    // XStats
+    pub xstats: Option<XStats>,
+
+    pub bps: Option<u32>,
+    pub pps: Option<u32>,
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum QDisc {
+    FqCodel(FqCodelQDisc),
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum XStats {
+    FqCodel(FqCodelXStats),
+}
+
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct FqCodelQDisc {
+    pub target: u32,
+    pub limit: u32,
+    pub interval: u32,
+    pub ecn: u32,
+    pub flows: u32,
+    pub quantum: u32,
+    pub ce_threshold: u32,
+    pub drop_batch_size: u32,
+    pub memory_limit: u32,
+}
+
+impl FqCodelQDisc {
+    pub fn new(fq_codel: &tc::FqCodel) -> Self {
+        Self {
+            target: fq_codel.target,
+            limit: fq_codel.limit,
+            interval: fq_codel.interval,
+            ecn: fq_codel.ecn,
+            flows: fq_codel.flows,
+            quantum: fq_codel.quantum,
+            ce_threshold: fq_codel.ce_threshold,
+            drop_batch_size: fq_codel.drop_batch_size,
+            memory_limit: fq_codel.memory_limit,
+        }
+    }
+}
+
+impl From<FqCodelQDisc> for QDisc {
+    fn from(val: FqCodelQDisc) -> Self {
+        QDisc::FqCodel(val)
+    }
+}
+
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct FqCodelXStats {
+    pub maxpacket: u32,
+    pub drop_overlimit: u32,
+    pub ecn_mark: u32,
+    pub new_flow_count: u32,
+    pub new_flows_len: u32,
+    pub old_flows_len: u32,
+    pub ce_mark: u32,
+    pub memory_usage: u32,
+    pub drop_overmemory: u32,
+}
+
+impl FqCodelXStats {
+    pub fn new(xstats: &tc::FqCodelXStats) -> Self {
+        Self {
+            maxpacket: xstats.maxpacket,
+            drop_overlimit: xstats.drop_overlimit,
+            ecn_mark: xstats.ecn_mark,
+            new_flow_count: xstats.new_flow_count,
+            new_flows_len: xstats.new_flows_len,
+            old_flows_len: xstats.old_flows_len,
+            ce_mark: xstats.ce_mark,
+            memory_usage: xstats.memory_usage,
+            drop_overmemory: xstats.drop_overmemory,
+        }
+    }
+}


### PR DESCRIPTION
The PR is broken into modular commits, so it might be easier to review the PR commit-by-commit.

Commit: [Add sub-module for reading `tc` stats](https://github.com/facebookincubator/below/pull/8209/commits/922e4a59408e5d4b3a3b032455b1edb2ecaa4d67)
  - Uses `netlink-tc` library which reads `tc` `qdisc` and `class` via rtnetlink

Commit: [Add model to represent `tc` stats](https://github.com/facebookincubator/below/pull/8209/commits/36ebcc3d5cd38fcff99892651df88dc9e60f74cb)
  - Defined a `TcModel` struct to represent the diff between two `Tc` stats sample

Commit: [Add dump command and implement Dumper for rendering TcModel](https://github.com/facebookincubator/below/pull/8209/commits/e2264d74bfd00e9947f4ad6830a33379685f6774)
  - Add dump and render configs for `tc` fields and model

Commit: [Fix and add more UTs](https://github.com/facebookincubator/below/pull/8209/commits/0c25f98133ac36e6e2d91fe5a1b29e328632cfaa)