### PR TITLE
Add sub-module for reading `tc` stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
  "libc",
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hostname"
@@ -1529,7 +1529,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "below-common",
  "below-ethtool",
  "below-gpu-stats",
+ "below-tc",
  "below_derive",
  "cgroupfs",
  "enum-iterator",
@@ -322,6 +323,19 @@ dependencies = [
  "tempfile",
  "zstd",
  "zstd-safe",
+]
+
+[[package]]
+name = "below-tc"
+version = "0.0.1"
+dependencies = [
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-sys",
+ "nix 0.27.1",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -377,6 +391,12 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1295,12 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "maplit"
@@ -1366,6 +1383,54 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,9 +400,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -598,7 +598,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
@@ -1356,6 +1356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,7 +1443,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
  "pin-utils",
 ]
 
@@ -1447,6 +1456,7 @@ dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "below/render",
   "below/resctrlfs",
   "below/store",
+  "below/tc",
   "below/view",
 ]
 resolver = "2"

--- a/below/config/src/lib.rs
+++ b/below/config/src/lib.rs
@@ -47,6 +47,7 @@ pub struct BelowConfig {
     pub btrfs_min_pct: f64,
     pub enable_ethtool_stats: bool,
     pub enable_resctrl_stats: bool,
+    pub enable_tc_stats: bool,
 }
 
 impl Default for BelowConfig {
@@ -63,6 +64,7 @@ impl Default for BelowConfig {
             btrfs_min_pct: btrfs::DEFAULT_MIN_PCT,
             enable_ethtool_stats: false,
             enable_resctrl_stats: false,
+            enable_tc_stats: false,
         }
     }
 }

--- a/below/dump/src/command.rs
+++ b/below/dump/src/command.rs
@@ -26,6 +26,7 @@ use model::SingleDiskModelFieldId;
 use model::SingleNetModelFieldId;
 use model::SingleProcessModelFieldId;
 use model::SingleQueueModelFieldId;
+use model::SingleTcModelFieldId;
 use model::SystemModelFieldId;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -1036,6 +1037,81 @@ $ below dump ethtool-queue -b "08:30:00" -e "08:30:30" -O json
     )
 });
 
+/// Represents the fields of the tc model.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    below_derive::EnumFromStr,
+    below_derive::EnumToString
+)]
+pub enum TcAggField {
+    Stats,
+    XStats,
+    QDisc,
+}
+
+impl AggField<SingleTcModelFieldId> for TcAggField {
+    fn expand(&self, _detail: bool) -> Vec<SingleTcModelFieldId> {
+        use model::SingleTcModelFieldId as FieldId;
+
+        match self {
+            Self::Stats => vec![
+                FieldId::Interface,
+                FieldId::Kind,
+                FieldId::Qlen,
+                FieldId::Bps,
+                FieldId::Pps,
+                FieldId::BytesPerSec,
+                FieldId::PacketsPerSec,
+                FieldId::BacklogPerSec,
+                FieldId::DropsPerSec,
+                FieldId::RequeuesPerSec,
+                FieldId::OverlimitsPerSec,
+            ],
+            Self::XStats => enum_iterator::all::<model::XStatsModelFieldId>()
+                .map(FieldId::Xstats)
+                .collect::<Vec<_>>(),
+            Self::QDisc => enum_iterator::all::<model::QDiscModelFieldId>()
+                .map(FieldId::Qdisc)
+                .collect::<Vec<_>>(),
+        }
+    }
+}
+
+pub type TcOptionField = DumpOptionField<SingleTcModelFieldId, TcAggField>;
+
+pub static DEFAULT_TC_FIELDS: &[TcOptionField] = &[
+    DumpOptionField::Unit(DumpField::Common(CommonField::Datetime)),
+    DumpOptionField::Agg(TcAggField::Stats),
+    DumpOptionField::Agg(TcAggField::XStats),
+    DumpOptionField::Agg(TcAggField::QDisc),
+    DumpOptionField::Unit(DumpField::Common(CommonField::Timestamp)),
+];
+
+const TC_ABOUT: &str = "Dump the tc related stats with qdiscs";
+
+/// Generated about message for tc (traffic control) dump so supported fields are up-to-date.
+static TC_LONG_ABOUT: Lazy<String> = Lazy::new(|| {
+    format!(
+        r#"{about}
+********************** Available fields **********************
+{common_fields}, {tc_fields}.
+********************** Aggregated fields **********************
+* --detail: no effect.
+* --default: includes [{default_fields}].
+* --everything: includes everything (equivalent to --default --detail).
+********************** Example Commands **********************
+Example:
+$ below dump tc -b "08:30:00" -e "08:30:30" -O json
+"#,
+        about = TC_ABOUT,
+        common_fields = join(enum_iterator::all::<CommonField>()),
+        tc_fields = join(enum_iterator::all::<SingleTcModelFieldId>()),
+        default_fields = join(DEFAULT_TC_FIELDS.to_owned()),
+    )
+});
+
 make_option! (OutputFormat {
     "raw": Raw,
     "csv": Csv,
@@ -1216,6 +1292,17 @@ pub enum DumpCommand {
         #[clap(flatten)]
         opts: GeneralOpt,
         /// Saved pattern in the dumprc file under [ethtool] section.
+        #[clap(long, short, conflicts_with("fields"))]
+        pattern: Option<String>,
+    },
+    #[clap(about = TC_ABOUT, long_about = TC_LONG_ABOUT.as_str())]
+    Tc {
+        /// Select which fields to display and in what order.
+        #[clap(short, long)]
+        fields: Option<Vec<TcOptionField>>,
+        #[clap(flatten)]
+        opts: GeneralOpt,
+        /// Saved pattern in the dumprc file under [tc] section.
         #[clap(long, short, conflicts_with("fields"))]
         pattern: Option<String>,
     },

--- a/below/dump/src/lib.rs
+++ b/below/dump/src/lib.rs
@@ -52,8 +52,8 @@ pub mod network;
 pub mod print;
 pub mod process;
 pub mod system;
-pub mod tmain;
 pub mod tc;
+pub mod tmain;
 pub mod transport;
 
 #[cfg(test)]

--- a/below/dump/src/lib.rs
+++ b/below/dump/src/lib.rs
@@ -53,6 +53,7 @@ pub mod print;
 pub mod process;
 pub mod system;
 pub mod tmain;
+pub mod tc;
 pub mod transport;
 
 #[cfg(test)]
@@ -117,6 +118,7 @@ pub type IfaceField = DumpField<model::SingleNetModelFieldId>;
 // Essentially the same as NetworkField
 pub type TransportField = DumpField<model::NetworkModelFieldId>;
 pub type EthtoolQueueField = DumpField<model::SingleQueueModelFieldId>;
+pub type TcField = DumpField<model::SingleTcModelFieldId>;
 
 fn get_advance(
     logger: slog::Logger,
@@ -553,6 +555,42 @@ pub fn run(
                 time_begin,
                 time_end,
                 &ethtool,
+                output.as_mut(),
+                opts.output_format,
+                opts.br,
+                errs,
+            )
+        }
+        DumpCommand::Tc {
+            fields,
+            opts,
+            pattern,
+        } => {
+            let (time_begin, time_end, advance) =
+                get_advance(logger, dir, host, port, snapshot, &opts)?;
+            let detail = opts.everything || opts.detail;
+            let fields = if let Some(pattern_key) = pattern {
+                parse_pattern(filename, pattern_key, "tc")
+            } else {
+                fields
+            };
+            let fields = expand_fields(
+                match fields.as_ref() {
+                    Some(fields) => fields,
+                    _ => command::DEFAULT_TC_FIELDS,
+                },
+                detail,
+            );
+            let tc = tc::Tc::new(&opts, fields);
+            let mut output: Box<dyn Write> = match opts.output.as_ref() {
+                Some(file_path) => Box::new(File::create(file_path)?),
+                None => Box::new(io::stdout()),
+            };
+            dump_timeseries(
+                advance,
+                time_begin,
+                time_end,
+                &tc,
                 output.as_mut(),
                 opts.output_format,
                 opts.br,

--- a/below/dump/src/tc.rs
+++ b/below/dump/src/tc.rs
@@ -1,0 +1,104 @@
+use super::*;
+use model::SingleTcModel;
+
+pub struct Tc {
+    opts: GeneralOpt,
+    fields: Vec<TcField>,
+}
+
+impl Tc {
+    pub fn new(opts: &GeneralOpt, fields: Vec<TcField>) -> Self {
+        Self {
+            opts: opts.to_owned(),
+            fields,
+        }
+    }
+}
+
+impl Dumper for Tc {
+    fn dump_model(
+        &self,
+        ctx: &CommonFieldContext,
+        model: &model::Model,
+        output: &mut dyn Write,
+        round: &mut usize,
+        comma_flag: bool,
+    ) -> Result<IterExecResult> {
+        let tcs: Vec<&SingleTcModel> = match &model.tc {
+            Some(tc_model) => tc_model.tc.iter().collect(),
+            None => Vec::new(),
+        };
+        if tcs.is_empty() {
+            return Ok(IterExecResult::Skip);
+        }
+
+        let mut json_output = json!([]);
+
+        tcs.into_iter()
+            .map(|tc| {
+                match self.opts.output_format {
+                    Some(OutputFormat::Raw) | None => write!(
+                        output,
+                        "{}",
+                        print::dump_raw(
+                            &self.fields,
+                            ctx,
+                            tc,
+                            *round,
+                            self.opts.repeat_title,
+                            self.opts.disable_title,
+                            self.opts.raw
+                        )
+                    )?,
+                    Some(OutputFormat::Csv) => write!(
+                        output,
+                        "{}",
+                        print::dump_csv(
+                            &self.fields,
+                            ctx,
+                            tc,
+                            *round,
+                            self.opts.disable_title,
+                            self.opts.raw
+                        )
+                    )?,
+                    Some(OutputFormat::Tsv) => write!(
+                        output,
+                        "{}",
+                        print::dump_tsv(
+                            &self.fields,
+                            ctx,
+                            tc,
+                            *round,
+                            self.opts.disable_title,
+                            self.opts.raw
+                        )
+                    )?,
+                    Some(OutputFormat::KeyVal) => write!(
+                        output,
+                        "{}",
+                        print::dump_kv(&self.fields, ctx, tc, self.opts.raw)
+                    )?,
+                    Some(OutputFormat::Json) => {
+                        let par = print::dump_json(&self.fields, ctx, tc, self.opts.raw);
+                        json_output.as_array_mut().unwrap().push(par);
+                    }
+                    Some(OutputFormat::OpenMetrics) => {
+                        write!(output, "{}", print::dump_openmetrics(&self.fields, ctx, tc))?
+                    }
+                }
+                *round += 1;
+                Ok(())
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        match (self.opts.output_format, comma_flag) {
+            (Some(OutputFormat::Json), true) => write!(output, ",{}", json_output)?,
+            (Some(OutputFormat::Json), false) => write!(output, "{}", json_output)?,
+            (Some(OutputFormat::OpenMetrics), _) => (),
+            _ => writeln!(output)?,
+        };
+
+        Ok(IterExecResult::Success)
+    }
+}

--- a/below/dump/src/test.rs
+++ b/below/dump/src/test.rs
@@ -1338,9 +1338,7 @@ fn test_dump_tc_content() {
         network: model::NetworkModel::default(),
         gpu: None,
         resctrl: None,
-        tc: Some(model::TcModel {
-            tc: tc_models,
-        }),
+        tc: Some(model::TcModel { tc: tc_models }),
     };
 
     let mut opts: GeneralOpt = Default::default();

--- a/below/model/Cargo.toml
+++ b/below/model/Cargo.toml
@@ -27,6 +27,7 @@ resctrlfs = { version = "0.8.0", path = "../resctrlfs" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
+tc = { package = "below-tc", version = "0.0.1", path = "../tc" }
 
 [dev-dependencies]
 futures = { version = "0.3.30", features = ["async-await", "compat"] }

--- a/below/model/src/collector.rs
+++ b/below/model/src/collector.rs
@@ -318,7 +318,7 @@ fn collect_sample(
                     Default::default()
                 }
             }
-        }
+        },
     })
 }
 

--- a/below/model/src/collector_plugin.rs
+++ b/below/model/src/collector_plugin.rs
@@ -155,14 +155,14 @@ mod test {
             // Test overwriting sample
             futures::executor::block_on(collector.collect_and_update()).unwrap();
             c.wait(); // <-- 1
-                      // Consumer checking overwritten sample
+            // Consumer checking overwritten sample
             c.wait(); // <-- 2
-                      // Test sending None
+            // Test sending None
             futures::executor::block_on(collector.collect_and_update()).unwrap();
             c.wait(); // <-- 3
-                      // Consumer checking None
+            // Consumer checking None
             c.wait(); // <-- 4
-                      // Test sending error. Will fail on both collector and consumer threads.
+            // Test sending error. Will fail on both collector and consumer threads.
             let is_error = matches!(
                 futures::executor::block_on(collector.collect_and_update()),
                 Err(_)

--- a/below/model/src/collector_plugin.rs
+++ b/below/model/src/collector_plugin.rs
@@ -155,14 +155,14 @@ mod test {
             // Test overwriting sample
             futures::executor::block_on(collector.collect_and_update()).unwrap();
             c.wait(); // <-- 1
-            // Consumer checking overwritten sample
+                      // Consumer checking overwritten sample
             c.wait(); // <-- 2
-            // Test sending None
+                      // Test sending None
             futures::executor::block_on(collector.collect_and_update()).unwrap();
             c.wait(); // <-- 3
-            // Consumer checking None
+                      // Consumer checking None
             c.wait(); // <-- 4
-            // Test sending error. Will fail on both collector and consumer threads.
+                      // Test sending error. Will fail on both collector and consumer threads.
             let is_error = matches!(
                 futures::executor::block_on(collector.collect_and_update()),
                 Err(_)
@@ -174,11 +174,11 @@ mod test {
         barrier.wait(); // <-- 1
         assert_eq!(Some(2), consumer.try_take().unwrap());
         barrier.wait(); // <-- 2
-        // Collector sending None
+                        // Collector sending None
         barrier.wait(); // <-- 3
         assert_eq!(None, consumer.try_take().unwrap());
         barrier.wait(); // <-- 4
-        // Collector sending error
+                        // Collector sending error
         barrier.wait(); // <-- 5
         assert!(matches!(consumer.try_take(), Err(_)));
 

--- a/below/model/src/common_field_ids.rs
+++ b/below/model/src/common_field_ids.rs
@@ -23,7 +23,7 @@
 ///
 /// This list also servers as documentation for available field ids that could
 /// be used in other below crates. A test ensures that this list is up-to-date.
-pub const COMMON_MODEL_FIELD_IDS: [&str; 445] = [
+pub const COMMON_MODEL_FIELD_IDS: [&str; 449] = [
     "system.hostname",
     "system.kernel_version",
     "system.os_release",

--- a/below/model/src/common_field_ids.rs
+++ b/below/model/src/common_field_ids.rs
@@ -23,7 +23,7 @@
 ///
 /// This list also servers as documentation for available field ids that could
 /// be used in other below crates. A test ensures that this list is up-to-date.
-pub const COMMON_MODEL_FIELD_IDS: [&str; 420] = [
+pub const COMMON_MODEL_FIELD_IDS: [&str; 445] = [
     "system.hostname",
     "system.kernel_version",
     "system.os_release",
@@ -444,4 +444,33 @@ pub const COMMON_MODEL_FIELD_IDS: [&str; 420] = [
     "network.udp6.sndbuf_errors",
     "network.udp6.in_csum_errors",
     "network.udp6.ignored_multi",
+    "tc.tc.<idx>.backlog_per_sec",
+    "tc.tc.<idx>.bps",
+    "tc.tc.<idx>.bytes_per_sec",
+    "tc.tc.<idx>.interface",
+    "tc.tc.<idx>.drops_per_sec",
+    "tc.tc.<idx>.kind",
+    "tc.tc.<idx>.overlimits_per_sec",
+    "tc.tc.<idx>.packets_per_sec",
+    "tc.tc.<idx>.pps",
+    "tc.tc.<idx>.qdisc.fq_codel.ce_threshold",
+    "tc.tc.<idx>.qdisc.fq_codel.drop_batch_size",
+    "tc.tc.<idx>.qdisc.fq_codel.ecn",
+    "tc.tc.<idx>.qdisc.fq_codel.flows_per_sec",
+    "tc.tc.<idx>.qdisc.fq_codel.interval",
+    "tc.tc.<idx>.qdisc.fq_codel.limit",
+    "tc.tc.<idx>.qdisc.fq_codel.memory_limit",
+    "tc.tc.<idx>.qdisc.fq_codel.quantum",
+    "tc.tc.<idx>.qdisc.fq_codel.target",
+    "tc.tc.<idx>.qlen",
+    "tc.tc.<idx>.requeues_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.ce_mark",
+    "tc.tc.<idx>.xstats.fq_codel.drop_overlimit_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.drop_overmemory_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.ecn_mark",
+    "tc.tc.<idx>.xstats.fq_codel.maxpacket",
+    "tc.tc.<idx>.xstats.fq_codel.memory_usage_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.new_flow_count_per_sec",
+    "tc.tc.<idx>.xstats.fq_codel.new_flows_len",
+    "tc.tc.<idx>.xstats.fq_codel.old_flows_len",
 ];

--- a/below/model/src/lib.rs
+++ b/below/model/src/lib.rs
@@ -41,6 +41,7 @@ pub mod sample;
 mod sample_model;
 pub mod system;
 pub mod tc_model;
+pub mod tc_collector_plugin;
 
 open_source_shim!(pub);
 

--- a/below/model/src/lib.rs
+++ b/below/model/src/lib.rs
@@ -41,8 +41,8 @@ pub mod resctrl;
 pub mod sample;
 mod sample_model;
 pub mod system;
-pub mod tc_model;
 pub mod tc_collector_plugin;
+pub mod tc_model;
 
 open_source_shim!(pub);
 

--- a/below/model/src/lib.rs
+++ b/below/model/src/lib.rs
@@ -40,6 +40,7 @@ pub mod resctrl;
 pub mod sample;
 mod sample_model;
 pub mod system;
+pub mod tc_model;
 
 open_source_shim!(pub);
 
@@ -50,6 +51,7 @@ pub use process::*;
 pub use resctrl::*;
 pub use sample::*;
 pub use system::*;
+pub use tc_model::*;
 
 /// A wrapper for different field types used in Models. By this way we can query
 /// different fields in a single function without using Box.
@@ -535,6 +537,8 @@ pub struct Model {
     pub gpu: Option<GpuModel>,
     #[queriable(subquery)]
     pub resctrl: Option<ResctrlModel>,
+    #[queriable(subquery)]
+    pub tc: Option<TcModel>,
 }
 
 impl Model {
@@ -588,6 +592,16 @@ impl Model {
                     r,
                     if let Some((s, d)) = last {
                         s.resctrl.as_ref().map(|r| (r, d))
+                    } else {
+                        None
+                    },
+                )
+            }),
+            tc: sample.tc.as_ref().map(|tc| {
+                TcModel::new(
+                    tc,
+                    if let Some((s, d)) = last {
+                        s.tc.as_ref().map(|tc| (tc, d))
                     } else {
                         None
                     },

--- a/below/model/src/sample.rs
+++ b/below/model/src/sample.rs
@@ -23,6 +23,7 @@ pub struct Sample {
     pub gpus: Option<gpu_stats::GpuSample>,
     pub ethtool: Option<ethtool::EthtoolStats>,
     pub resctrl: Option<resctrlfs::ResctrlSample>,
+    pub tc: Option<tc::TcStats>,
 }
 
 #[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]

--- a/below/model/src/sample_model.rs
+++ b/below/model/src/sample_model.rs
@@ -926,6 +926,49 @@ pub const SAMPLE_MODEL_JSON: &str = r#"
             "in_csum_errors": 0,
             "ignored_multi": 0
         }
+    },
+    "tc": {
+        "tc": [
+            {
+                "interface": "eth0",
+                "kind": "fq_codel",
+                "qlen": 42,
+                "bps": 420,
+                "pps": 1337,
+                "bytes_per_sec": 299792458,
+                "packets_per_sec": 314,
+                "backlog_per_sec": 2718281828,
+                "drops_per_sec": 8675309,
+                "requeues_per_sec": 12345,
+                "overlimits_per_sec": 314159,
+                "qdisc": {
+                    "fq_codel": {
+                        "target": 2701,
+                        "limit": 7,
+                        "interval": 3,
+                        "ecn": 6,
+                        "quantum": 42,
+                        "ce_threshold": 101,
+                        "drop_batch_size": 9000,
+                        "memory_limit": 123456,
+                        "flows_per_sec": 31415
+                    }
+                },
+                "xstats": {
+                    "fq_codel": {
+                        "maxpacket": 8675309,
+                        "ecn_mark": 299792458,
+                        "new_flows_len": 314,
+                        "old_flows_len": 1729,
+                        "ce_mark": 42,
+                        "drop_overlimit_per_sec": 420,
+                        "new_flow_count_per_sec": 1337,
+                        "memory_usage_per_sec": 2718281828,
+                        "drop_overmemory_per_sec": 27182
+                    }
+                }
+            }
+        ]
     }
 }
 "#;

--- a/below/model/src/tc_collector_plugin.rs
+++ b/below/model/src/tc_collector_plugin.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use slog::error;
+use tc::TcStats;
+
+use crate::collector_plugin::AsyncCollectorPlugin;
+
+pub type SampleType = TcStats;
+
+pub struct TcStatsCollectorPlugin {
+    logger: slog::Logger,
+}
+
+impl TcStatsCollectorPlugin {
+    pub fn new(logger: slog::Logger) -> Result<Self> {
+        Ok(Self { logger })
+    }
+}
+
+#[async_trait]
+impl AsyncCollectorPlugin for TcStatsCollectorPlugin {
+    type T = TcStats;
+
+    async fn try_collect(&mut self) -> Result<Option<SampleType>> {
+        let stats = match tc::tc_stats() {
+            Ok(tc_stats) => Some(tc_stats),
+            Err(e) => {
+                error!(self.logger, "{:#}", e);
+                Default::default()
+            }
+        };
+
+        Ok(stats)
+    }
+}

--- a/below/model/src/tc_model.rs
+++ b/below/model/src/tc_model.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::{Field, FieldId, Nameable, Queriable};
-use tc::{QDisc, Tc, XStats};
+use tc::{QDisc, TcStat, TcStats, XStats};
 
 /// rate! macro calculates the rate of a field for given sample and last objects.
 /// It basically calls count_per_sec! macro after extracting the field from the objects.
@@ -32,7 +32,7 @@ pub struct TcModel {
 }
 
 impl TcModel {
-    pub fn new(sample: &Vec<Tc>, last: Option<(&Vec<Tc>, Duration)>) -> Self {
+    pub fn new(sample: &TcStats, last: Option<(&TcStats, Duration)>) -> Self {
         // Assumption: sample and last are always ordered
         let tc = match last {
             Some((last_tcs, d)) if last_tcs.len() == sample.len() => sample
@@ -87,7 +87,7 @@ impl Nameable for SingleTcModel {
 }
 
 impl SingleTcModel {
-    pub fn new(sample: &Tc, last: Option<(&Tc, Duration)>) -> Self {
+    pub fn new(sample: &TcStat, last: Option<(&TcStat, Duration)>) -> Self {
         let mut tc_model = SingleTcModel {
             interface: sample.if_name.clone(),
             kind: sample.kind.clone(),

--- a/below/model/src/tc_model.rs
+++ b/below/model/src/tc_model.rs
@@ -183,14 +183,13 @@ pub struct XStatsModel {
 impl XStatsModel {
     fn new(sample: &XStats, last: Option<(&XStats, Duration)>) -> Option<Self> {
         match (sample, last) {
-            (XStats::FqCodel(sample), Some((XStats::FqCodel(last), d))) => {
-                match (sample, last) {
-                    (tc::FqCodelXStats::FqCodelQdiscStats(sample), tc::FqCodelXStats::FqCodelQdiscStats(last)) => {
-                        Some(Self {
-                            fq_codel: Some(FqCodelXStatsModel::new(sample, Some((last, d)))),
-                        })
-                    },
-                }
+            (XStats::FqCodel(sample), Some((XStats::FqCodel(last), d))) => match (sample, last) {
+                (
+                    tc::FqCodelXStats::FqCodelQdiscStats(sample),
+                    tc::FqCodelXStats::FqCodelQdiscStats(last),
+                ) => Some(Self {
+                    fq_codel: Some(FqCodelXStatsModel::new(sample, Some((last, d)))),
+                }),
             },
             _ => None,
         }

--- a/below/model/src/tc_model.rs
+++ b/below/model/src/tc_model.rs
@@ -17,15 +17,7 @@ macro_rules! rate {
     }};
 }
 
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    below_derive::Queriable
-)]
+#[below_derive::queriable_derives]
 pub struct TcModel {
     #[queriable(subquery)]
     pub tc: Vec<SingleTcModel>,
@@ -47,15 +39,7 @@ impl TcModel {
     }
 }
 
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    below_derive::Queriable
-)]
+#[below_derive::queriable_derives]
 pub struct SingleTcModel {
     /// Name of the interface
     pub interface: String,
@@ -125,15 +109,7 @@ impl SingleTcModel {
     }
 }
 
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    below_derive::Queriable
-)]
+#[below_derive::queriable_derives]
 pub struct QDiscModel {
     #[queriable(subquery)]
     pub fq_codel: Option<FqCodelQDiscModel>,
@@ -156,15 +132,7 @@ impl QDiscModel {
     }
 }
 
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    below_derive::Queriable
-)]
+#[below_derive::queriable_derives]
 pub struct FqCodelQDiscModel {
     pub target: u32,
     pub limit: u32,

--- a/below/model/src/tc_model.rs
+++ b/below/model/src/tc_model.rs
@@ -1,4 +1,8 @@
-use super::*;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Field, FieldId, Nameable, Queriable};
 use tc::{QDisc, Tc, XStats};
 
 /// rate! macro calculates the rate of a field for given sample and last objects.

--- a/below/model/src/tc_model.rs
+++ b/below/model/src/tc_model.rs
@@ -1,0 +1,268 @@
+use super::*;
+use tc::{QDisc, Tc, XStats};
+
+/// rate! macro calculates the rate of a field for given sample and last objects.
+/// It basically calls count_per_sec! macro after extracting the field from the objects.
+macro_rules! rate {
+    ($field:ident, $sample:ident, $last:ident, $target_type:ty) => {{
+        $last.and_then(|(last, d)| {
+            let s = $sample.$field;
+            let l = last.$field;
+            count_per_sec!(l, s, d, $target_type)
+        })
+    }};
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct TcModel {
+    #[queriable(subquery)]
+    pub tc: Vec<SingleTcModel>,
+}
+
+impl TcModel {
+    pub fn new(
+        sample: &Vec<Tc>,
+        last: Option<(&Vec<Tc>, Duration)>,
+    ) -> Self {
+        // Assumption: sample and last are always ordered
+        let tc = match last {
+            Some((last_tcs, d)) if last_tcs.len() == sample.len() => {
+                sample.iter()
+                    .zip(last_tcs.iter())
+                    .map(|(sample, last)| SingleTcModel::new(sample, Some((last, d))))
+                    .collect::<Vec<_>>()
+            }
+            _ => Vec::new(),
+        };
+
+        Self { tc }
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct SingleTcModel {
+    /// Name of the interface
+    pub interface: String,
+    /// Name of the qdisc
+    pub kind: String,
+
+    pub qlen: Option<u32>,
+    pub bps: Option<u32>,
+    pub pps: Option<u32>,
+
+    pub bytes_per_sec: Option<u64>,
+    pub packets_per_sec: Option<u32>,
+    pub backlog_per_sec: Option<u32>,
+    pub drops_per_sec: Option<u32>,
+    pub requeues_per_sec: Option<u32>,
+    pub overlimits_per_sec: Option<u32>,
+
+    #[queriable(subquery)]
+    pub qdisc: Option<QDiscModel>,
+
+    #[queriable(subquery)]
+    pub xstats: Option<XStatsModel>,
+}
+
+impl Nameable for SingleTcModel {
+    fn name() -> &'static str {
+        "tc"
+    }
+}
+
+impl SingleTcModel {
+    pub fn new(sample: &Tc, last: Option<(&Tc, Duration)>) -> Self {
+        let mut tc_model = SingleTcModel {
+            interface: sample.if_name.clone(),
+            kind: sample.kind.clone(),
+            ..Default::default()
+        };
+
+        let stats = &sample.stats;
+        tc_model.qlen = stats.qlen;
+        tc_model.bps = stats.bps;
+        tc_model.pps = stats.pps;
+
+        last.map(|(l, d)| {
+            let last = &l.stats;
+            tc_model.bytes_per_sec = count_per_sec!(last.bytes, stats.bytes, d, u64);
+            tc_model.packets_per_sec = count_per_sec!(last.packets, stats.packets, d, u32);
+            tc_model.backlog_per_sec = count_per_sec!(last.backlog, stats.backlog, d, u32);
+            tc_model.drops_per_sec = count_per_sec!(last.drops, stats.drops, d, u32);
+            tc_model.requeues_per_sec = count_per_sec!(last.requeues, stats.requeues, d, u32);
+            tc_model.overlimits_per_sec = count_per_sec!(last.overlimits, stats.overlimits, d, u32);
+        });
+
+        if let Some(sample) = stats.xstats.as_ref() {
+            let last =
+                last.and_then(|(last, d)| last.stats.xstats.as_ref().map(|l| (l, d)));
+
+            tc_model.xstats = Some(XStatsModel::new(sample, last));
+        }
+
+        if let Some(sample) = sample.qdisc.as_ref() {
+            let last = last.and_then(|(last, d)| last.qdisc.as_ref().map(|l| (l, d)));
+
+            tc_model.qdisc = Some(QDiscModel::new(sample, last));
+        }
+
+        tc_model
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct QDiscModel {
+    #[queriable(subquery)]
+    pub fq_codel: Option<FqCodelQDiscModel>,
+}
+
+impl QDiscModel {
+    fn new(sample: &QDisc, last: Option<(&QDisc, Duration)>) -> Self {
+        match sample {
+            QDisc::FqCodel(sample) => Self {
+                fq_codel: {
+                    last.map(|(l, d)| match l {
+                        QDisc::FqCodel(last) => {
+                            let last = Some((last, d));
+                            FqCodelQDiscModel::new(sample, last)
+                        }
+                    })
+                },
+            },
+        }
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct FqCodelQDiscModel {
+    pub target: u32,
+    pub limit: u32,
+    pub interval: u32,
+    pub ecn: u32,
+    pub quantum: u32,
+    pub ce_threshold: u32,
+    pub drop_batch_size: u32,
+    pub memory_limit: u32,
+    pub flows_per_sec: Option<u32>,
+}
+
+impl FqCodelQDiscModel {
+    fn new(sample: &tc::FqCodelQDisc, last: Option<(&tc::FqCodelQDisc, Duration)>) -> Self {
+        Self {
+            target: sample.target,
+            limit: sample.limit,
+            interval: sample.interval,
+            ecn: sample.ecn,
+            quantum: sample.quantum,
+            ce_threshold: sample.ce_threshold,
+            drop_batch_size: sample.drop_batch_size,
+            memory_limit: sample.memory_limit,
+            flows_per_sec: {
+                last.and_then(|l| {
+                    let last = Some(l);
+                    rate!(flows, sample, last, u32)
+                })
+            },
+        }
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct XStatsModel {
+    #[queriable(subquery)]
+    pub fq_codel: Option<FqCodelXStatsModel>,
+}
+
+impl XStatsModel {
+    fn new(sample: &XStats, last: Option<(&XStats, Duration)>) -> Self {
+        match sample {
+            XStats::FqCodel(sample) => Self {
+                fq_codel: {
+                    last.map(|(l, d)| match l {
+                        XStats::FqCodel(last) => {
+                            let last = Some((last, d));
+                            FqCodelXStatsModel::new(sample, last)
+                        }
+                    })
+                },
+            },
+        }
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    below_derive::Queriable
+)]
+pub struct FqCodelXStatsModel {
+    pub maxpacket: u32,
+    pub ecn_mark: u32,
+    pub new_flows_len: u32,
+    pub old_flows_len: u32,
+    pub ce_mark: u32,
+    pub drop_overlimit_per_sec: Option<u32>,
+    pub new_flow_count_per_sec: Option<u32>,
+    pub memory_usage_per_sec: Option<u32>,
+    pub drop_overmemory_per_sec: Option<u32>,
+}
+
+impl FqCodelXStatsModel {
+    fn new(sample: &tc::FqCodelXStats, last: Option<(&tc::FqCodelXStats, Duration)>) -> Self {
+        Self {
+            maxpacket: sample.maxpacket,
+            ecn_mark: sample.ecn_mark,
+            new_flows_len: sample.new_flows_len,
+            old_flows_len: sample.old_flows_len,
+            ce_mark: sample.ce_mark,
+            drop_overlimit_per_sec: rate!(drop_overlimit, sample, last, u32),
+            new_flow_count_per_sec: rate!(drop_overlimit, sample, last, u32),
+            memory_usage_per_sec: rate!(drop_overlimit, sample, last, u32),
+            drop_overmemory_per_sec: rate!(drop_overlimit, sample, last, u32),
+        }
+    }
+}

--- a/below/model/src/tc_model.rs
+++ b/below/model/src/tc_model.rs
@@ -28,18 +28,14 @@ pub struct TcModel {
 }
 
 impl TcModel {
-    pub fn new(
-        sample: &Vec<Tc>,
-        last: Option<(&Vec<Tc>, Duration)>,
-    ) -> Self {
+    pub fn new(sample: &Vec<Tc>, last: Option<(&Vec<Tc>, Duration)>) -> Self {
         // Assumption: sample and last are always ordered
         let tc = match last {
-            Some((last_tcs, d)) if last_tcs.len() == sample.len() => {
-                sample.iter()
-                    .zip(last_tcs.iter())
-                    .map(|(sample, last)| SingleTcModel::new(sample, Some((last, d))))
-                    .collect::<Vec<_>>()
-            }
+            Some((last_tcs, d)) if last_tcs.len() == sample.len() => sample
+                .iter()
+                .zip(last_tcs.iter())
+                .map(|(sample, last)| SingleTcModel::new(sample, Some((last, d))))
+                .collect::<Vec<_>>(),
             _ => Vec::new(),
         };
 
@@ -110,8 +106,7 @@ impl SingleTcModel {
         });
 
         if let Some(sample) = stats.xstats.as_ref() {
-            let last =
-                last.and_then(|(last, d)| last.stats.xstats.as_ref().map(|l| (l, d)));
+            let last = last.and_then(|(last, d)| last.stats.xstats.as_ref().map(|l| (l, d)));
 
             tc_model.xstats = Some(XStatsModel::new(sample, last));
         }

--- a/below/render/src/default_configs.rs
+++ b/below/render/src/default_configs.rs
@@ -1552,3 +1552,183 @@ impl HasRenderConfig for model::CgroupProperties {
         }
     }
 }
+
+impl HasRenderConfig for model::SingleTcModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::SingleTcModelFieldId::*;
+        let rc = RenderConfigBuilder::new();
+        match field_id {
+            Interface => rc.title("Interface"),
+            Kind => rc.title("Kind"),
+            Qlen => rc.title("Queue Length"),
+            Bps => rc.title("Bps").format(ReadableSize).suffix("/s"),
+            Pps => rc.title("Pps").suffix("/s"),
+            BytesPerSec => rc.title("Bytes").format(ReadableSize).suffix("/s"),
+            PacketsPerSec => rc.title("Packets").suffix("/s"),
+            BacklogPerSec => rc.title("Backlog").suffix("/s"),
+            DropsPerSec => rc.title("Drops").suffix("/s"),
+            RequeuesPerSec => rc.title("Requeues").suffix("/s"),
+            OverlimitsPerSec => rc.title("Overlimits").suffix("/s"),
+            Qdisc(field_id) => model::QDiscModel::get_render_config_builder(field_id),
+            Xstats(field_id) => model::XStatsModel::get_render_config_builder(field_id),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::SingleTcModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::SingleTcModelFieldId::*;
+        let gauge = gauge()
+            .label("interface", &self.interface)
+            .label("qdisc", &self.kind);
+        match field_id {
+            Interface => None,
+            Kind => None,
+            Qlen => Some(gauge),
+            Bps => Some(gauge.unit("bytes_per_second")),
+            Pps => Some(gauge.unit("packets_per_second")),
+            BytesPerSec => Some(gauge.unit("bytes_per_second")),
+            PacketsPerSec => Some(gauge.unit("packets_per_second")),
+            BacklogPerSec => Some(gauge.unit("packets_per_second")),
+            DropsPerSec => Some(gauge.unit("packets_per_second")),
+            RequeuesPerSec => Some(gauge.unit("packets_per_second")),
+            OverlimitsPerSec => Some(gauge.unit("packets_per_second")),
+            Qdisc(field_id) => self
+                .qdisc
+                .as_ref()
+                .and_then(|qdisc| qdisc.get_openmetrics_config_for_dump(field_id)),
+            Xstats(field_id) => self
+                .xstats
+                .as_ref()
+                .and_then(|xstats| xstats.get_openmetrics_config_for_dump(field_id)),
+        }
+    }
+}
+
+impl HasRenderConfig for model::QDiscModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::QDiscModelFieldId::*;
+        match field_id {
+            FqCodel(field_id) => model::FqCodelQDiscModel::get_render_config_builder(field_id),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::QDiscModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::QDiscModelFieldId::*;
+        match field_id {
+            FqCodel(field_id) => self
+                .fq_codel
+                .as_ref()
+                .and_then(|fq_codel| fq_codel.get_openmetrics_config_for_dump(field_id)),
+        }
+    }
+}
+
+impl HasRenderConfig for model::FqCodelQDiscModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::FqCodelQDiscModelFieldId::*;
+        let rc = RenderConfigBuilder::new();
+        match field_id {
+            Target => rc.title("Target"),
+            Limit => rc.title("Limit"),
+            Interval => rc.title("Interval"),
+            Ecn => rc.title("Ecn"),
+            Quantum => rc.title("Quantum"),
+            CeThreshold => rc.title("CeThreshold"),
+            DropBatchSize => rc.title("DropBatchSize"),
+            MemoryLimit => rc.title("MemoryLimit"),
+            FlowsPerSec => rc.title("Flows").suffix("/s"),
+        }
+    }
+}
+
+impl HasRenderConfig for model::XStatsModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::XStatsModelFieldId::*;
+        match field_id {
+            FqCodel(field_id) => model::FqCodelXStatsModel::get_render_config_builder(field_id),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::XStatsModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::XStatsModelFieldId::*;
+        match field_id {
+            FqCodel(field_id) => self
+                .fq_codel
+                .as_ref()
+                .and_then(|fq_codel| fq_codel.get_openmetrics_config_for_dump(field_id)),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::FqCodelQDiscModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::FqCodelQDiscModelFieldId::*;
+        match field_id {
+            Target => Some(gauge()),
+            Limit => Some(gauge()),
+            Interval => Some(gauge()),
+            Ecn => Some(gauge()),
+            Quantum => Some(gauge()),
+            CeThreshold => Some(gauge()),
+            DropBatchSize => Some(gauge()),
+            MemoryLimit => Some(gauge()),
+            FlowsPerSec => Some(gauge()),
+        }
+    }
+}
+
+impl HasRenderConfig for model::FqCodelXStatsModel {
+    fn get_render_config_builder(field_id: &Self::FieldId) -> RenderConfigBuilder {
+        use model::FqCodelXStatsModelFieldId::*;
+        let rc = RenderConfigBuilder::new();
+        match field_id {
+            Maxpacket => rc.title("MaxPacket"),
+            EcnMark => rc.title("EcnMark"),
+            NewFlowsLen => rc.title("NewFlowsLen"),
+            OldFlowsLen => rc.title("OldFlowsLen"),
+            CeMark => rc.title("CeMark"),
+            DropOverlimitPerSec => rc.title("DropOverlimit").suffix("/s"),
+            NewFlowCountPerSec => rc.title("NewFlowCount").suffix("/s"),
+            MemoryUsagePerSec => rc.title("MemoryUsage").suffix("/s"),
+            DropOvermemoryPerSec => rc.title("DropOvermemory").suffix("/s"),
+        }
+    }
+}
+
+impl HasRenderConfigForDump for model::FqCodelXStatsModel {
+    fn get_openmetrics_config_for_dump(
+        &self,
+        field_id: &Self::FieldId,
+    ) -> Option<RenderOpenMetricsConfigBuilder> {
+        use model::FqCodelXStatsModelFieldId::*;
+        let gauge = gauge();
+        match field_id {
+            Maxpacket => Some(gauge),
+            EcnMark => Some(gauge),
+            NewFlowsLen => Some(gauge),
+            OldFlowsLen => Some(gauge),
+            CeMark => Some(gauge),
+            DropOverlimitPerSec => Some(gauge),
+            NewFlowCountPerSec => Some(gauge),
+            MemoryUsagePerSec => Some(gauge),
+            DropOvermemoryPerSec => Some(gauge),
+        }
+    }
+}

--- a/below/src/main.rs
+++ b/below/src/main.rs
@@ -1012,6 +1012,7 @@ fn record(
             enable_btrfs_stats: below_config.enable_btrfs_stats,
             enable_ethtool_stats: below_config.enable_ethtool_stats,
             enable_resctrl_stats: below_config.enable_resctrl_stats,
+            enable_tc_stats: below_config.enable_tc_stats,
             btrfs_samples: below_config.btrfs_samples,
             btrfs_min_pct: below_config.btrfs_min_pct,
             cgroup_re,

--- a/below/tc/Cargo.toml
+++ b/below/tc/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "below-tc"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+netlink-packet-core = "0.7.0"
+netlink-packet-route = "0.19.0"
+netlink-packet-utils = "0.5.2"
+netlink-sys = "0.8.5"
+nix = { version = "0.27.1",  features = ["net"] }
+thiserror = "1.0"
+serde = { version = "1.0", features = ["derive", "rc"] }

--- a/below/tc/README.md
+++ b/below/tc/README.md
@@ -1,0 +1,5 @@
+# tc
+
+`tc` is a rust library that parses the queueing discipline ([qdisc](https://tldp.org/HOWTO/Traffic-Control-HOWTO/components.html#c-qdisc)) component of the Traffic Control ([`tc`](http://man7.org/linux/man-pages/man8/tc.8.html)) Linux subsystem.
+
+The library depends on another upstream library https://github.com/rust-netlink/netlink-packet-route for parsing the [netlink](https://www.kernel.org/doc/html/latest/userspace-api/netlink/intro.html) response which is then converted into an intermediate representation to be consumed by the `model` library.  

--- a/below/tc/src/errors.rs
+++ b/below/tc/src/errors.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TcError {
+    #[error("Netlink error: {0}")]
+    Netlink(String),
+
+    #[error("Read interfaces error: {0}")]
+    ReadInterfaces(String),
+
+    #[error("Failed to read tc stats: {0}")]
+    Read(String),
+}

--- a/below/tc/src/lib.rs
+++ b/below/tc/src/lib.rs
@@ -17,9 +17,9 @@ use netlink_sys::{Socket, SocketAddr};
 use nix::net::if_;
 
 use errors::TcError;
-pub use types::{FqCodelQDisc, FqCodelXStats, QDisc, Tc, XStats};
+pub use types::{FqCodelQDisc, FqCodelXStats, QDisc, TcStat, XStats};
 
-pub type TcStats = Vec<Tc>;
+pub type TcStats = Vec<TcStat>;
 type Result<T> = std::result::Result<T, TcError>;
 
 /// Get list of all `tc` qdiscs.
@@ -35,7 +35,7 @@ fn read_tc_stats(
     let messages = netlink_retriever()?;
     let tc_stats = messages
         .into_iter()
-        .map(|msg| Tc::new(&interfaces, &msg))
+        .map(|msg| TcStat::new(&interfaces, &msg))
         .collect();
 
     Ok(tc_stats)

--- a/below/tc/src/lib.rs
+++ b/below/tc/src/lib.rs
@@ -35,7 +35,12 @@ fn read_tc_stats(
     let messages = netlink_retriever()?;
     let tc_stats = messages
         .into_iter()
-        .map(|msg| TcStat::new(&interfaces, &msg))
+        .filter_map(|msg| {
+            interfaces
+                .get(&(msg.header.index as u32))
+                .cloned()
+                .map(|if_name| TcStat::new(if_name, &msg))
+        })
         .collect();
 
     Ok(tc_stats)

--- a/below/tc/src/lib.rs
+++ b/below/tc/src/lib.rs
@@ -17,7 +17,7 @@ use netlink_sys::{Socket, SocketAddr};
 use nix::net::if_;
 
 use errors::TcError;
-pub use types::{FqCodelQDisc, FqCodelXStats, QDisc, TcStat, XStats};
+pub use types::{FqCodelQDisc, FqCodelQdStats, FqCodelXStats, QDisc, TcStat, XStats};
 
 pub type TcStats = Vec<TcStat>;
 type Result<T> = std::result::Result<T, TcError>;

--- a/below/tc/src/lib.rs
+++ b/below/tc/src/lib.rs
@@ -1,0 +1,111 @@
+mod errors;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use std::collections::BTreeMap;
+
+use netlink_packet_core::{NetlinkHeader, NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+use netlink_packet_route::RouteNetlinkMessage;
+use netlink_packet_route::tc::TcMessage;
+use netlink_sys::constants::NETLINK_ROUTE;
+use netlink_sys::{Socket, SocketAddr};
+use nix::net::if_;
+
+pub use errors::*;
+pub use types::*;
+
+pub type TcStats = Vec<Tc>;
+pub type Result<T> = std::result::Result<T, TcError>;
+
+/// Get list of all `tc` qdiscs.
+pub fn tc_stats() -> Result<TcStats> {
+    let ifaces = get_interfaces()?;
+    read_tc_stats(ifaces, &get_netlink_qdiscs)
+}
+
+fn read_tc_stats(interfaces: BTreeMap<u32, String>, netlink_retriever: &dyn Fn() -> Result<Vec<TcMessage>>) -> Result<TcStats> {
+    let messages = netlink_retriever()?;
+    let tc_stats = messages
+        .into_iter()
+        .map(|msg| Tc::new(&interfaces, &msg))
+        .collect();
+
+    Ok(tc_stats)
+}
+
+/// Open a netlink socket to retrieve `tc` qdiscs.
+/// The underlying library sends a message of type `RTM_GETQDISC` to the kernel.
+/// The kernel responds with a message of type `RTM_NEWQDISC` for each qdisc.
+fn get_netlink_qdiscs() -> Result<Vec<TcMessage>> {
+    // open a socket
+    let socket = Socket::new(NETLINK_ROUTE).map_err(|e| TcError::Netlink(e.to_string()))?;
+    socket.connect(&SocketAddr::new(0, 0)).map_err(|e| TcError::Netlink(e.to_string()))?;
+
+    // create a netlink request
+    let mut nl_hdr = NetlinkHeader::default();
+    nl_hdr.flags = NLM_F_REQUEST | NLM_F_DUMP;
+    let msg = RouteNetlinkMessage::GetQueueDiscipline(TcMessage::default());
+    let mut packet = NetlinkMessage::new(nl_hdr, NetlinkPayload::from(msg));
+    packet.finalize();
+    let mut buf = vec![0; packet.header.length as usize];
+    packet.serialize(&mut buf[..]);
+
+    // send the request
+    socket.send(&buf[..], 0).map_err(|e| TcError::Netlink(e.to_string()))?;
+
+    // receive the response
+    let mut recv_buf = vec![0; 4096];
+    let mut offset = 0;
+    let mut response = Vec::new();
+    'out: while let Ok(size) = socket.recv(&mut &mut recv_buf[offset..], 0) {
+        loop {
+            let bytes = &recv_buf[offset..];
+            let rx_packet = <NetlinkMessage<RouteNetlinkMessage>>::deserialize(bytes)
+                .map_err(|e| TcError::Netlink(e.to_string()))?;
+            response.push(rx_packet.clone());
+            let payload = rx_packet.payload;
+            if let NetlinkPayload::Error(err) = payload {
+                return Err(TcError::Netlink(err.to_string()));
+            }
+            if let NetlinkPayload::Done(_) = payload {
+                break 'out;
+            }
+
+            offset += rx_packet.header.length as usize;
+            if offset == size || rx_packet.header.length == 0 {
+                offset = 0;
+                break;
+            }
+        }
+    }
+
+    let mut tc_msgs = Vec::new();
+    for msg in response {
+        if let NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewQueueDiscipline(tc)) = msg.payload {
+            tc_msgs.push(tc);
+        }
+    }
+
+    return Ok(tc_msgs);
+}
+
+/// Get a map of interface index to interface name.
+fn get_interfaces() -> Result<BTreeMap<u32, String>> {
+    let ifaces = if_::if_nameindex().map_err(|e| TcError::ReadInterfaces(e.to_string()))?;
+    let if_map = ifaces
+    .iter()
+    .map(|iface| {
+        let index = iface.index();
+        let name = if let Ok(name) = iface.name().to_str() {
+            name.to_string()
+        } else {
+            String::new()
+        };
+        (index, name)
+    })
+    .collect::<BTreeMap<u32, String>>();
+
+    Ok(if_map)
+}

--- a/below/tc/src/lib.rs
+++ b/below/tc/src/lib.rs
@@ -16,11 +16,11 @@ use netlink_sys::constants::NETLINK_ROUTE;
 use netlink_sys::{Socket, SocketAddr};
 use nix::net::if_;
 
-pub use errors::*;
-pub use types::*;
+use errors::TcError;
+pub use types::{FqCodelQDisc, FqCodelXStats, QDisc, Tc, XStats};
 
 pub type TcStats = Vec<Tc>;
-pub type Result<T> = std::result::Result<T, TcError>;
+type Result<T> = std::result::Result<T, TcError>;
 
 /// Get list of all `tc` qdiscs.
 pub fn tc_stats() -> Result<TcStats> {

--- a/below/tc/src/test.rs
+++ b/below/tc/src/test.rs
@@ -5,7 +5,7 @@ use netlink_packet_route::tc::{
     TcQdiscFqCodelOption, TcStats, TcStats2, TcStatsBasic, TcStatsQueue, TcXstats,
 };
 
-use crate::{types::XStats, FqCodelQDisc, FqCodelXStats, QDisc, Result};
+use crate::{types::XStats, FqCodelQDisc, FqCodelQdStats, FqCodelXStats, QDisc, Result};
 
 fn fake_netlink_qdiscs() -> Result<Vec<TcMessage>> {
     let mut tc_msgs = Vec::new();
@@ -114,16 +114,18 @@ fn test_tc_stats() {
     // xstats
     assert_eq!(
         tc.stats.xstats,
-        Some(XStats::FqCodel(FqCodelXStats {
-            maxpacket: 258,
-            drop_overlimit: 0,
-            ecn_mark: 0,
-            new_flow_count: 91,
-            new_flows_len: 0,
-            old_flows_len: 0,
-            ce_mark: 0,
-            memory_usage: 0,
-            drop_overmemory: 0,
-        }))
+        Some(XStats::FqCodel(FqCodelXStats::FqCodelQdiscStats(
+            FqCodelQdStats {
+                maxpacket: 258,
+                drop_overlimit: 0,
+                ecn_mark: 0,
+                new_flow_count: 91,
+                new_flows_len: 0,
+                old_flows_len: 0,
+                ce_mark: 0,
+                memory_usage: 0,
+                drop_overmemory: 0,
+            }
+        )))
     );
 }

--- a/below/tc/src/test.rs
+++ b/below/tc/src/test.rs
@@ -1,9 +1,11 @@
+use std::collections::BTreeMap;
+
 use netlink_packet_route::tc::{
     TcAttribute, TcFqCodelQdStats, TcFqCodelXstats, TcHandle, TcHeader, TcMessage, TcOption,
     TcQdiscFqCodelOption, TcStats, TcStats2, TcStatsBasic, TcStatsQueue, TcXstats,
 };
 
-use super::*;
+use crate::{types::XStats, FqCodelQDisc, FqCodelXStats, QDisc, Result};
 
 fn fake_netlink_qdiscs() -> Result<Vec<TcMessage>> {
     let mut tc_msgs = Vec::new();
@@ -79,7 +81,7 @@ fn fake_netlink_qdiscs() -> Result<Vec<TcMessage>> {
 #[test]
 fn test_tc_stats() {
     let ifaces = BTreeMap::from_iter(vec![(2, "eth0".to_string())]);
-    let tc_map = read_tc_stats(ifaces, &fake_netlink_qdiscs).unwrap();
+    let tc_map = crate::read_tc_stats(ifaces, &fake_netlink_qdiscs).unwrap();
 
     let tc = tc_map.get(0).unwrap();
     assert_eq!(tc.if_index, 2);

--- a/below/tc/src/test.rs
+++ b/below/tc/src/test.rs
@@ -1,4 +1,7 @@
-use netlink_packet_route::tc::{TcAttribute, TcFqCodelQdStats, TcFqCodelXstats, TcHandle, TcHeader, TcMessage, TcOption, TcQdiscFqCodelOption, TcStats, TcStats2, TcStatsBasic, TcStatsQueue, TcXstats};
+use netlink_packet_route::tc::{
+    TcAttribute, TcFqCodelQdStats, TcFqCodelXstats, TcHandle, TcHeader, TcMessage, TcOption,
+    TcQdiscFqCodelOption, TcStats, TcStats2, TcStatsBasic, TcStatsQueue, TcXstats,
+};
 
 use super::*;
 
@@ -53,24 +56,20 @@ fn fake_netlink_qdiscs() -> Result<Vec<TcMessage>> {
                     queue
                 }),
             ]),
-            TcAttribute::Xstats(
-                TcXstats::FqCodel(
-                    TcFqCodelXstats::Qdisc({
-                        let mut fq_codel = TcFqCodelQdStats::default();
-                        fq_codel.maxpacket = 258;
-                        fq_codel.drop_overlimit = 0;
-                        fq_codel.ecn_mark = 0;
-                        fq_codel.new_flow_count = 91;
-                        fq_codel.new_flows_len = 0;
-                        fq_codel.old_flows_len = 0;
-                        fq_codel.ce_mark = 0;
-                        fq_codel.memory_usage = 0;
-                        fq_codel.drop_overmemory = 0;
-                        fq_codel
-                    }
-                )
-            )
-        ),],
+            TcAttribute::Xstats(TcXstats::FqCodel(TcFqCodelXstats::Qdisc({
+                let mut fq_codel = TcFqCodelQdStats::default();
+                fq_codel.maxpacket = 258;
+                fq_codel.drop_overlimit = 0;
+                fq_codel.ecn_mark = 0;
+                fq_codel.new_flow_count = 91;
+                fq_codel.new_flows_len = 0;
+                fq_codel.old_flows_len = 0;
+                fq_codel.ce_mark = 0;
+                fq_codel.memory_usage = 0;
+                fq_codel.drop_overmemory = 0;
+                fq_codel
+            }))),
+        ],
     );
     tc_msgs.push(msg1);
 
@@ -95,28 +94,34 @@ fn test_tc_stats() {
     assert_eq!(tc.stats.pps, Some(400));
 
     // qdisc
-    assert_eq!(tc.qdisc, Some(QDisc::FqCodel(FqCodelQDisc {
-        target: 4999,
-        limit: 10240,
-        interval: 99999,
-        ecn: 1,
-        flows: 1024,
-        quantum: 1514,
-        ce_threshold: 0,
-        drop_batch_size: 64,
-        memory_limit: 33554432,
-    })));
+    assert_eq!(
+        tc.qdisc,
+        Some(QDisc::FqCodel(FqCodelQDisc {
+            target: 4999,
+            limit: 10240,
+            interval: 99999,
+            ecn: 1,
+            flows: 1024,
+            quantum: 1514,
+            ce_threshold: 0,
+            drop_batch_size: 64,
+            memory_limit: 33554432,
+        }))
+    );
 
     // xstats
-    assert_eq!(tc.stats.xstats, Some(XStats::FqCodel(FqCodelXStats {
-        maxpacket: 258,
-        drop_overlimit: 0,
-        ecn_mark: 0,
-        new_flow_count: 91,
-        new_flows_len: 0,
-        old_flows_len: 0,
-        ce_mark: 0,
-        memory_usage: 0,
-        drop_overmemory: 0,
-    })));
+    assert_eq!(
+        tc.stats.xstats,
+        Some(XStats::FqCodel(FqCodelXStats {
+            maxpacket: 258,
+            drop_overlimit: 0,
+            ecn_mark: 0,
+            new_flow_count: 91,
+            new_flows_len: 0,
+            old_flows_len: 0,
+            ce_mark: 0,
+            memory_usage: 0,
+            drop_overmemory: 0,
+        }))
+    );
 }

--- a/below/tc/src/test.rs
+++ b/below/tc/src/test.rs
@@ -1,0 +1,122 @@
+use netlink_packet_route::tc::{TcAttribute, TcFqCodelQdStats, TcFqCodelXstats, TcHandle, TcHeader, TcMessage, TcOption, TcQdiscFqCodelOption, TcStats, TcStats2, TcStatsBasic, TcStatsQueue, TcXstats};
+
+use super::*;
+
+fn fake_netlink_qdiscs() -> Result<Vec<TcMessage>> {
+    let mut tc_msgs = Vec::new();
+
+    let msg1 = TcMessage::from_parts(
+        TcHeader {
+            index: 2,
+            handle: TcHandle::from(0),
+            parent: TcHandle::from(2),
+            ..Default::default()
+        },
+        vec![
+            TcAttribute::Kind("fq_codel".to_string()),
+            TcAttribute::Options(vec![
+                TcOption::FqCodel(TcQdiscFqCodelOption::Target(4999u32)),
+                TcOption::FqCodel(TcQdiscFqCodelOption::Limit(10240u32)),
+                TcOption::FqCodel(TcQdiscFqCodelOption::Interval(99999u32)),
+                TcOption::FqCodel(TcQdiscFqCodelOption::Ecn(1u32)),
+                TcOption::FqCodel(TcQdiscFqCodelOption::Flows(1024u32)),
+                TcOption::FqCodel(TcQdiscFqCodelOption::Quantum(1514u32)),
+                TcOption::FqCodel(TcQdiscFqCodelOption::CeThreshold(0u32)),
+                TcOption::FqCodel(TcQdiscFqCodelOption::DropBatchSize(64u32)),
+                TcOption::FqCodel(TcQdiscFqCodelOption::MemoryLimit(33554432u32)),
+            ]),
+            TcAttribute::Stats({
+                let mut stats = TcStats::default();
+                stats.bytes = 39902796u64;
+                stats.packets = 165687u32;
+                stats.drops = 100u32;
+                stats.overlimits = 200u32;
+                stats.bps = 300u32;
+                stats.pps = 400u32;
+                stats.qlen = 500u32;
+                stats.backlog = 10u32;
+                stats
+            }),
+            TcAttribute::Stats2(vec![
+                TcStats2::Basic({
+                    let mut basic = TcStatsBasic::default();
+                    basic.bytes = 39902796u64;
+                    basic.packets = 165687u32;
+                    basic
+                }),
+                TcStats2::Queue({
+                    let mut queue = TcStatsQueue::default();
+                    queue.qlen = 500u32;
+                    queue.drops = 100u32;
+                    queue.requeues = 50u32;
+                    queue.overlimits = 20u32;
+                    queue
+                }),
+            ]),
+            TcAttribute::Xstats(
+                TcXstats::FqCodel(
+                    TcFqCodelXstats::Qdisc({
+                        let mut fq_codel = TcFqCodelQdStats::default();
+                        fq_codel.maxpacket = 258;
+                        fq_codel.drop_overlimit = 0;
+                        fq_codel.ecn_mark = 0;
+                        fq_codel.new_flow_count = 91;
+                        fq_codel.new_flows_len = 0;
+                        fq_codel.old_flows_len = 0;
+                        fq_codel.ce_mark = 0;
+                        fq_codel.memory_usage = 0;
+                        fq_codel.drop_overmemory = 0;
+                        fq_codel
+                    }
+                )
+            )
+        ),],
+    );
+    tc_msgs.push(msg1);
+
+    Ok(tc_msgs)
+}
+
+#[test]
+fn test_tc_stats() {
+    let ifaces = BTreeMap::from_iter(vec![(2, "eth0".to_string())]);
+    let tc_map = read_tc_stats(ifaces, &fake_netlink_qdiscs).unwrap();
+
+    let tc = tc_map.get(0).unwrap();
+    assert_eq!(tc.if_index, 2);
+    assert_eq!(tc.handle, 0);
+    assert_eq!(tc.parent, 2);
+
+    assert_eq!(tc.kind, "fq_codel");
+    assert_eq!(tc.stats.bytes, Some(39902796));
+    assert_eq!(tc.stats.packets, Some(165687));
+    assert_eq!(tc.stats.qlen, Some(500));
+    assert_eq!(tc.stats.bps, Some(300));
+    assert_eq!(tc.stats.pps, Some(400));
+
+    // qdisc
+    assert_eq!(tc.qdisc, Some(QDisc::FqCodel(FqCodelQDisc {
+        target: 4999,
+        limit: 10240,
+        interval: 99999,
+        ecn: 1,
+        flows: 1024,
+        quantum: 1514,
+        ce_threshold: 0,
+        drop_batch_size: 64,
+        memory_limit: 33554432,
+    })));
+
+    // xstats
+    assert_eq!(tc.stats.xstats, Some(XStats::FqCodel(FqCodelXStats {
+        maxpacket: 258,
+        drop_overlimit: 0,
+        ecn_mark: 0,
+        new_flow_count: 91,
+        new_flows_len: 0,
+        old_flows_len: 0,
+        ce_mark: 0,
+        memory_usage: 0,
+        drop_overmemory: 0,
+    })));
+}

--- a/below/tc/src/types.rs
+++ b/below/tc/src/types.rs
@@ -10,7 +10,7 @@ const FQ_CODEL: &str = "fq_codel";
 
 /// `Tc` represents a traffic control qdisc.
 #[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct Tc {
+pub struct TcStat {
     /// Index of the network interface.
     pub if_index: u32,
     /// Name of the network interface.
@@ -27,7 +27,7 @@ pub struct Tc {
     pub qdisc: Option<QDisc>,
 }
 
-impl Tc {
+impl TcStat {
     pub fn new(interfaces: &BTreeMap<u32, String>, tc_msg: &TcMessage) -> Self {
         let if_index = tc_msg.header.index as u32;
         let if_name = interfaces

--- a/below/tc/src/types.rs
+++ b/below/tc/src/types.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use netlink_packet_route::tc;
 use netlink_packet_route::tc::{
     TcAttribute, TcFqCodelXstats, TcMessage, TcOption, TcQdiscFqCodelOption,
@@ -28,11 +26,8 @@ pub struct TcStat {
 }
 
 impl TcStat {
-    pub fn new(interfaces: &BTreeMap<u32, String>, tc_msg: &TcMessage) -> Self {
+    pub fn new(if_name: String, tc_msg: &TcMessage) -> Self {
         let if_index = tc_msg.header.index as u32;
-        let if_name = interfaces
-            .get(&if_index)
-            .map_or_else(String::new, |iface| iface.to_string());
         let mut tc = Self {
             if_index,
             if_name,

--- a/below/tc/src/types.rs
+++ b/below/tc/src/types.rs
@@ -11,12 +11,19 @@ const FQ_CODEL: &str = "fq_codel";
 /// `Tc` represents a traffic control qdisc.
 #[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Tc {
+    /// Index of the network interface.
     pub if_index: u32,
+    /// Name of the network interface.
     pub if_name: String,
+    /// A unique identifier for the qdisc.
     pub handle: u32,
+    /// Identifier of the parent qdisc.
     pub parent: u32,
+    /// Type of the queueing discipline, e.g. `fq_codel`, `htb`, etc.
     pub kind: String,
+    /// Detailed statistics of the qdisc, such as bytes, packets, qlen, etc.
     pub stats: Stats,
+    /// qdisc wraps the specific qdisc type, e.g. `fq_codel`.
     pub qdisc: Option<QDisc>,
 }
 
@@ -81,23 +88,33 @@ impl Tc {
 #[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Stats {
     // Stats2::StatsBasic
+    /// Number of enqueued bytes.
     pub bytes: Option<u64>,
+    /// Number of enqueued packets.
     pub packets: Option<u32>,
 
     // Stats2::StatsQueue
+    /// Length of the queue.
     pub qlen: Option<u32>,
+    /// Number of bytes pending in the queue.
     pub backlog: Option<u32>,
+    /// Packets dropped because of lack of resources.
     pub drops: Option<u32>,
     pub requeues: Option<u32>,
+    /// Number of throttle events when this flow goes out of allocated bandwidth.
     pub overlimits: Option<u32>,
 
     // XStats
+    /// xstats wraps extended statistics of the qdisc.
     pub xstats: Option<XStats>,
 
+    /// Current flow byte rate.
     pub bps: Option<u32>,
+    /// Current flow packet rate.
     pub pps: Option<u32>,
 }
 
+/// `QDisc` represents the queueing discipline of a network interface.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum QDisc {
     FqCodel(FqCodelQDisc),
@@ -143,27 +160,45 @@ pub enum XStats {
 
 #[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct FqCodelQDisc {
+    /// Accceptable minimum standing/persistent queue delay.
     pub target: u32,
+    /// Hard limit on the real queue size.
     pub limit: u32,
+    /// Used to ensure that the measured minimum delay does not become too stale.
     pub interval: u32,
+    /// Used to mark packets instead of dropping them.
     pub ecn: u32,
+    /// Number of flows into which the incoming packets are classified.
     pub flows: u32,
+    /// Number of bytes used as 'deficit' in the fair queuing algorithm.
     pub quantum: u32,
+    /// Sets a threshold above which all packets are marked with ECN Congestion Experienced.
     pub ce_threshold: u32,
+    /// Sets the maximum number of packets to drop when limit or memory_limit is exceeded.
     pub drop_batch_size: u32,
+    /// Sets a limit on the total number of bytes that can be queued in this FQ-CoDel instance.
     pub memory_limit: u32,
 }
 
 #[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct FqCodelXStats {
+    /// Largest packet we've seen so far
     pub maxpacket: u32,
+    /// Number of time max qdisc packet limit was hit.
     pub drop_overlimit: u32,
+    /// Number of packets ECN marked instead of being dropped.
     pub ecn_mark: u32,
+    /// Number of time packets created a 'new flow'.
     pub new_flow_count: u32,
+    /// Count of flows in new list.
     pub new_flows_len: u32,
+    /// Count of flows in old list.
     pub old_flows_len: u32,
+    /// Packets above ce_threshold.
     pub ce_mark: u32,
+    /// Memory usage (bytes).
     pub memory_usage: u32,
+    /// Number of time packets were dropped due to memory limit.
     pub drop_overmemory: u32,
 }
 

--- a/below/tc/src/types.rs
+++ b/below/tc/src/types.rs
@@ -1,0 +1,182 @@
+use std::collections::BTreeMap;
+
+use netlink_packet_route::tc;
+use netlink_packet_route::tc::{TcAttribute, TcFqCodelXstats, TcMessage, TcOption, TcQdiscFqCodelOption};
+use serde::{Deserialize, Serialize};
+
+const FQ_CODEL: &str = "fq_codel";
+
+/// `Tc` represents a traffic control qdisc.
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Tc {
+    pub if_index: u32,
+    pub if_name: String,
+    pub handle: u32,
+    pub parent: u32,
+    pub kind: String,
+    pub stats: Stats,
+    pub qdisc: Option<QDisc>,
+}
+
+impl Tc {
+    pub fn new(interfaces: &BTreeMap<u32, String>, tc_msg: &TcMessage) -> Self {
+        let if_index = tc_msg.header.index as u32;
+        let if_name = interfaces.get(&if_index).map_or_else(String::new, |iface| iface.to_string());
+        let mut tc = Self {
+            if_index,
+            if_name,
+            handle: tc_msg.header.handle.into(),
+            parent: tc_msg.header.parent.into(),
+            ..Default::default()
+        };
+        let mut opts = Vec::new();
+
+        for attr in &tc_msg.attributes {
+            match attr {
+                TcAttribute::Kind(name) => tc.kind = name.clone(),
+                TcAttribute::Options(tc_opts) => opts = tc_opts.to_vec(),
+                TcAttribute::Stats(tc_stats) => {
+                    tc.stats.bps = Some(tc_stats.bps);
+                    tc.stats.pps = Some(tc_stats.pps);
+                }
+                TcAttribute::Stats2(tc_stats) => {
+                    for stat in tc_stats {
+                        match stat {
+                            tc::TcStats2::Basic(basic) => {
+                                tc.stats.bytes = Some(basic.bytes);
+                                tc.stats.packets = Some(basic.packets);
+                            }
+                            tc::TcStats2::Queue(queue) => {
+                                tc.stats.qlen = Some(queue.qlen);
+                                tc.stats.backlog = Some(queue.backlog);
+                                tc.stats.drops = Some(queue.drops);
+                                tc.stats.requeues = Some(queue.requeues);
+                                tc.stats.overlimits = Some(queue.overlimits);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                TcAttribute::Xstats(tc_xstats) => {
+                    match tc_xstats {
+                        tc::TcXstats::FqCodel(fq_codel_xstats) => {
+                            tc.stats.xstats = Some(XStats::FqCodel(FqCodelXStats::new(fq_codel_xstats)))
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+
+
+        tc.qdisc = QDisc::new(&tc.kind, opts);
+
+        tc
+    }
+}
+
+/// `Stats` represents the statistics of a qdisc.
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Stats {
+    // Stats2::StatsBasic
+    pub bytes: Option<u64>,
+    pub packets: Option<u32>,
+
+    // Stats2::StatsQueue
+    pub qlen: Option<u32>,
+    pub backlog: Option<u32>,
+    pub drops: Option<u32>,
+    pub requeues: Option<u32>,
+    pub overlimits: Option<u32>,
+
+    // XStats
+    pub xstats: Option<XStats>,
+
+    pub bps: Option<u32>,
+    pub pps: Option<u32>,
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum QDisc {
+    FqCodel(FqCodelQDisc),
+}
+
+impl QDisc {
+    fn new(kind: &str, opts: Vec<TcOption>) -> Option<Self> {
+        if kind == FQ_CODEL {
+            let mut fq_codel = FqCodelQDisc::default();
+            for opt in opts {
+                match opt {
+                    TcOption::FqCodel(fq_codel_opt) => {
+                        match fq_codel_opt {
+                            TcQdiscFqCodelOption::Target(target) => fq_codel.target = target,
+                            TcQdiscFqCodelOption::Limit(limit) => fq_codel.limit = limit,
+                            TcQdiscFqCodelOption::Interval(interval) => fq_codel.interval = interval,
+                            TcQdiscFqCodelOption::Ecn(ecn) => fq_codel.ecn = ecn,
+                            TcQdiscFqCodelOption::Flows(flows) => fq_codel.flows = flows,
+                            TcQdiscFqCodelOption::Quantum(quantum) => fq_codel.quantum = quantum,
+                            TcQdiscFqCodelOption::CeThreshold(ce_threshold) => fq_codel.ce_threshold = ce_threshold,
+                            TcQdiscFqCodelOption::DropBatchSize(drop_batch_size) => fq_codel.drop_batch_size = drop_batch_size,
+                            TcQdiscFqCodelOption::MemoryLimit(memory_limit) => fq_codel.memory_limit = memory_limit,
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            return Some(Self::FqCodel(fq_codel));
+        }
+        None
+    }
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum XStats {
+    FqCodel(FqCodelXStats),
+}
+
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct FqCodelQDisc {
+    pub target: u32,
+    pub limit: u32,
+    pub interval: u32,
+    pub ecn: u32,
+    pub flows: u32,
+    pub quantum: u32,
+    pub ce_threshold: u32,
+    pub drop_batch_size: u32,
+    pub memory_limit: u32,
+}
+
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct FqCodelXStats {
+    pub maxpacket: u32,
+    pub drop_overlimit: u32,
+    pub ecn_mark: u32,
+    pub new_flow_count: u32,
+    pub new_flows_len: u32,
+    pub old_flows_len: u32,
+    pub ce_mark: u32,
+    pub memory_usage: u32,
+    pub drop_overmemory: u32,
+}
+
+impl FqCodelXStats {
+    pub fn new(xstats: &TcFqCodelXstats) -> Self {
+        match xstats {
+            TcFqCodelXstats::Qdisc(qdisc) => Self {
+                maxpacket: qdisc.maxpacket,
+                drop_overlimit: qdisc.drop_overlimit,
+                ecn_mark: qdisc.ecn_mark,
+                new_flow_count: qdisc.new_flow_count,
+                new_flows_len: qdisc.new_flows_len,
+                old_flows_len: qdisc.old_flows_len,
+                ce_mark: qdisc.ce_mark,
+                memory_usage: qdisc.memory_usage,
+                drop_overmemory: qdisc.drop_overmemory,
+            },
+            _ => Self::default(),
+        }
+    }
+}

--- a/below/tc/src/types.rs
+++ b/below/tc/src/types.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 
 use netlink_packet_route::tc;
-use netlink_packet_route::tc::{TcAttribute, TcFqCodelXstats, TcMessage, TcOption, TcQdiscFqCodelOption};
+use netlink_packet_route::tc::{
+    TcAttribute, TcFqCodelXstats, TcMessage, TcOption, TcQdiscFqCodelOption,
+};
 use serde::{Deserialize, Serialize};
 
 const FQ_CODEL: &str = "fq_codel";
@@ -21,7 +23,9 @@ pub struct Tc {
 impl Tc {
     pub fn new(interfaces: &BTreeMap<u32, String>, tc_msg: &TcMessage) -> Self {
         let if_index = tc_msg.header.index as u32;
-        let if_name = interfaces.get(&if_index).map_or_else(String::new, |iface| iface.to_string());
+        let if_name = interfaces
+            .get(&if_index)
+            .map_or_else(String::new, |iface| iface.to_string());
         let mut tc = Self {
             if_index,
             if_name,
@@ -57,18 +61,15 @@ impl Tc {
                         }
                     }
                 }
-                TcAttribute::Xstats(tc_xstats) => {
-                    match tc_xstats {
-                        tc::TcXstats::FqCodel(fq_codel_xstats) => {
-                            tc.stats.xstats = Some(XStats::FqCodel(FqCodelXStats::new(fq_codel_xstats)))
-                        }
-                        _ => {}
+                TcAttribute::Xstats(tc_xstats) => match tc_xstats {
+                    tc::TcXstats::FqCodel(fq_codel_xstats) => {
+                        tc.stats.xstats = Some(XStats::FqCodel(FqCodelXStats::new(fq_codel_xstats)))
                     }
-                }
+                    _ => {}
+                },
                 _ => {}
             }
         }
-
 
         tc.qdisc = QDisc::new(&tc.kind, opts);
 
@@ -108,20 +109,24 @@ impl QDisc {
             let mut fq_codel = FqCodelQDisc::default();
             for opt in opts {
                 match opt {
-                    TcOption::FqCodel(fq_codel_opt) => {
-                        match fq_codel_opt {
-                            TcQdiscFqCodelOption::Target(target) => fq_codel.target = target,
-                            TcQdiscFqCodelOption::Limit(limit) => fq_codel.limit = limit,
-                            TcQdiscFqCodelOption::Interval(interval) => fq_codel.interval = interval,
-                            TcQdiscFqCodelOption::Ecn(ecn) => fq_codel.ecn = ecn,
-                            TcQdiscFqCodelOption::Flows(flows) => fq_codel.flows = flows,
-                            TcQdiscFqCodelOption::Quantum(quantum) => fq_codel.quantum = quantum,
-                            TcQdiscFqCodelOption::CeThreshold(ce_threshold) => fq_codel.ce_threshold = ce_threshold,
-                            TcQdiscFqCodelOption::DropBatchSize(drop_batch_size) => fq_codel.drop_batch_size = drop_batch_size,
-                            TcQdiscFqCodelOption::MemoryLimit(memory_limit) => fq_codel.memory_limit = memory_limit,
-                            _ => {}
+                    TcOption::FqCodel(fq_codel_opt) => match fq_codel_opt {
+                        TcQdiscFqCodelOption::Target(target) => fq_codel.target = target,
+                        TcQdiscFqCodelOption::Limit(limit) => fq_codel.limit = limit,
+                        TcQdiscFqCodelOption::Interval(interval) => fq_codel.interval = interval,
+                        TcQdiscFqCodelOption::Ecn(ecn) => fq_codel.ecn = ecn,
+                        TcQdiscFqCodelOption::Flows(flows) => fq_codel.flows = flows,
+                        TcQdiscFqCodelOption::Quantum(quantum) => fq_codel.quantum = quantum,
+                        TcQdiscFqCodelOption::CeThreshold(ce_threshold) => {
+                            fq_codel.ce_threshold = ce_threshold
                         }
-                    }
+                        TcQdiscFqCodelOption::DropBatchSize(drop_batch_size) => {
+                            fq_codel.drop_batch_size = drop_batch_size
+                        }
+                        TcQdiscFqCodelOption::MemoryLimit(memory_limit) => {
+                            fq_codel.memory_limit = memory_limit
+                        }
+                        _ => {}
+                    },
                     _ => {}
                 }
             }


### PR DESCRIPTION
- Adds the sub-crate for reading `tc` stats
- Uses `netlink-packet-route` library which reads `qdisc`s via rtnetlink

Result:
```sh
$ below dump tc -b '5s ago'
Datetime            Interface   Kind       Queue Length   Bps        Pps        Bytes      Packets    Backlog    Drops      Requeues   Overlimits   MaxPacket   EcnMark    NewFlowsLen   OldFlowsLen   CeMark     DropOverlimit   NewFlowCount   MemoryUsage   DropOvermemory   Target     Limit      Interval   Ecn        Quantum    CeThreshold   DropBatchSize   MemoryLimit   Flows      Timestamp
2024-01-30 20:24:31 lo          noqueue    0              0.0 B/s    0/s        0.0 B/s    0/s        0/s        0/s        0/s        0/s          ?           ?          ?             ?             ?          ?               ?              ?             ?                ?          ?          ?          ?          ?          ?             ?               ?             ?          1706646271
2024-01-30 20:24:31 ens5        mq         0              0.0 B/s    0/s        167 B/s    2/s        0/s        0/s        0/s        0/s          ?           ?          ?             ?             ?          ?               ?              ?             ?                ?          ?          ?          ?          ?          ?             ?               ?             ?          1706646271
2024-01-30 20:24:31 ens5        fq_codel   0              0.0 B/s    0/s        0.0 B/s    0/s        0/s        0/s        0/s        0/s          110         0          0             0             0          0/s             0/s            0/s           0/s              4999       10240      99999      1          1514       0             64              33554432      0/s        1706646271
2024-01-30 20:24:31 ens5        fq_codel   0              0.0 B/s    0/s        167 B/s    2/s        0/s        0/s        0/s        0/s          182         0          0             0             0          0/s             0/s            0/s           0/s              4999       10240      99999      1          1514       0             64              33554432      0/s        1706646271
```