### PR TITLE
Handle network stats parsing gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,11 +882,13 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 name = "fb_procfs"
 version = "0.7.1"
 dependencies = [
+ "below-common",
  "lazy_static",
  "libc",
  "nix 0.25.0",
  "openat",
  "serde",
+ "slog",
  "tempfile",
  "thiserror",
  "threadpool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,13 +882,13 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 name = "fb_procfs"
 version = "0.7.1"
 dependencies = [
- "below-common",
  "lazy_static",
  "libc",
  "nix 0.25.0",
  "openat",
  "serde",
  "slog",
+ "slog-term",
  "tempfile",
  "thiserror",
  "threadpool",

--- a/below/model/src/collector.rs
+++ b/below/model/src/collector.rs
@@ -200,7 +200,7 @@ fn collect_sample(logger: &slog::Logger, options: &CollectorOptions) -> Result<S
                 .collect(),
             exit_pidmap,
         ),
-        netstats: match procfs::NetReader::new().and_then(|v| v.read_netstat()) {
+        netstats: match procfs::NetReader::new(logger.clone()).and_then(|v| v.read_netstat()) {
             Ok(ns) => ns.into(),
             Err(e) => {
                 error!(logger, "{:#}", e);

--- a/below/procfs/Cargo.toml
+++ b/below/procfs/Cargo.toml
@@ -11,11 +11,13 @@ repository = "https://github.com/facebookincubator/below"
 license = "Apache-2.0"
 
 [dependencies]
+common = { package = "below-common", version = "0.7.1", path = "../common" }
 lazy_static = "1.4"
 libc = "0.2.139"
 nix = "0.25"
 openat = "0.1.21"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
+slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
 thiserror = "1.0.43"
 threadpool = "1.8.1"
 

--- a/below/procfs/Cargo.toml
+++ b/below/procfs/Cargo.toml
@@ -11,13 +11,13 @@ repository = "https://github.com/facebookincubator/below"
 license = "Apache-2.0"
 
 [dependencies]
-common = { package = "below-common", version = "0.7.1", path = "../common" }
 lazy_static = "1.4"
 libc = "0.2.139"
 nix = "0.25"
 openat = "0.1.21"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
+slog-term = "2.8"
 thiserror = "1.0.43"
 threadpool = "1.8.1"
 

--- a/below/procfs/src/lib.rs
+++ b/below/procfs/src/lib.rs
@@ -1305,21 +1305,21 @@ impl NetReader {
     }
 
     pub fn read_netstat(&self) -> Result<NetStat> {
-        let netstat_map = self.read_kv_diff_line("netstat")?;
-        let snmp_map = self.read_kv_diff_line("snmp")?;
-        let snmp6_map = self.read_kv_same_line("snmp6")?;
+        let netstat_map = self.read_kv_diff_line("netstat").ok();
+        let snmp_map = self.read_kv_diff_line("snmp").ok();
+        let snmp6_map = self.read_kv_same_line("snmp6").ok();
 
         Ok(NetStat {
-            interfaces: Some(self.read_net_map()?),
-            tcp: Some(Self::read_tcp_stat(&snmp_map)),
-            tcp_ext: Some(Self::read_tcp_ext_stat(&netstat_map)),
-            ip: Some(Self::read_ip_stat(&snmp_map)),
-            ip_ext: Some(Self::read_ip_ext_stat(&netstat_map)),
-            ip6: Some(Self::read_ip6_stat(&snmp6_map)),
-            icmp: Some(Self::read_icmp_stat(&snmp_map)),
-            icmp6: Some(Self::read_icmp6_stat(&snmp6_map)),
-            udp: Some(Self::read_udp_stat(&snmp_map)),
-            udp6: Some(Self::read_udp6_stat(&snmp6_map)),
+            interfaces: self.read_net_map().ok(),
+            tcp: snmp_map.as_ref().map(Self::read_tcp_stat),
+            tcp_ext: netstat_map.as_ref().map(Self::read_tcp_ext_stat),
+            ip: snmp_map.as_ref().map(Self::read_ip_stat),
+            ip_ext: netstat_map.as_ref().map(Self::read_ip_ext_stat),
+            ip6: snmp6_map.as_ref().map(Self::read_ip6_stat),
+            icmp: snmp_map.as_ref().map(Self::read_icmp_stat),
+            icmp6: snmp6_map.as_ref().map(Self::read_icmp6_stat),
+            udp: snmp_map.as_ref().map(Self::read_udp_stat),
+            udp6: snmp6_map.as_ref().map(Self::read_udp6_stat),
         })
     }
 }

--- a/below/procfs/src/lib.rs
+++ b/below/procfs/src/lib.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 use lazy_static::lazy_static;
 use nix::sys;
 use openat::Dir;
-use slog::warn;
+use slog::debug;
 use thiserror::Error;
 use threadpool::ThreadPool;
 
@@ -1334,7 +1334,7 @@ fn handle_io_error<K, V>(
     result: Result<BTreeMap<K, V>>,
 ) -> Result<Option<BTreeMap<K, V>>> {
     let netstat_map = if let Err(Error::IoError(_, err)) = result {
-        warn!(logger, "{:?}", err);
+        debug!(logger, "{:?}", err);
         None
     } else {
         Some(result?)

--- a/below/procfs/src/test.rs
+++ b/below/procfs/src/test.rs
@@ -1193,9 +1193,10 @@ fn test_read_net_stat() {
 }
 
 #[test]
-fn test_read_with_errors() {
+fn test_read_enoent() {
     let netsysfs = TestProcfs::new();
     write_net_map(&netsysfs);
+
     let netstat = netsysfs
         .get_net_reader()
         .read_netstat()
@@ -1210,6 +1211,19 @@ fn test_read_with_errors() {
     assert_eq!(netstat.icmp6, None);
     assert_eq!(netstat.udp, None);
     assert_eq!(netstat.udp6, None);
+}
+
+#[test]
+fn test_read_bad_file() {
+    let netsysfs = TestProcfs::new();
+    write_net_map(&netsysfs);
+    netsysfs.create_file_with_content("snmp", b"bad\nfile");
+
+    let err = netsysfs
+        .get_net_reader()
+        .read_netstat()
+        .unwrap_err();
+    assert!(matches!(err, crate::Error::InvalidFileFormat(_)));
 }
 
 fn verify_tcp(netstat: &NetStat) {

--- a/below/procfs/src/test.rs
+++ b/below/procfs/src/test.rs
@@ -1190,6 +1190,26 @@ fn test_read_net_stat() {
     verify_interfaces(&netstat);
 }
 
+#[test]
+fn test_read_with_errors() {
+    let netsysfs = TestProcfs::new();
+    write_net_map(&netsysfs);
+    let netstat = netsysfs
+        .get_net_reader()
+        .read_netstat()
+        .expect("Fail to get NetStat");
+    verify_interfaces(&netstat);
+    assert_eq!(netstat.tcp, None);
+    assert_eq!(netstat.tcp_ext, None);
+    assert_eq!(netstat.ip, None);
+    assert_eq!(netstat.ip_ext, None);
+    assert_eq!(netstat.ip6, None);
+    assert_eq!(netstat.icmp, None);
+    assert_eq!(netstat.icmp6, None);
+    assert_eq!(netstat.udp, None);
+    assert_eq!(netstat.udp6, None);
+}
+
 fn verify_tcp(netstat: &NetStat) {
     let tcp = netstat.tcp.as_ref().expect("Fail to collect tcp stats");
     assert_eq!(tcp.active_opens, Some(54_858_563));

--- a/below/procfs/src/test.rs
+++ b/below/procfs/src/test.rs
@@ -17,6 +17,7 @@ use std::io::Write;
 use std::os::unix::fs::symlink;
 use std::path::Path;
 
+use common::logutil::get_logger;
 use tempfile::TempDir;
 
 use crate::types::*;
@@ -80,11 +81,12 @@ impl TestProcfs {
     }
 
     fn get_net_reader(&self) -> NetReader {
+        let logger = get_logger();
         let iface_dir = self.path().join("iface");
         if !iface_dir.exists() {
             std::fs::create_dir(&iface_dir).expect("Failed to create iface dir");
         }
-        NetReader::new_with_custom_path(iface_dir, self.path().to_path_buf())
+        NetReader::new_with_custom_path(logger, iface_dir, self.path().to_path_buf())
             .expect("Fail to construct Net Reader")
     }
 


### PR DESCRIPTION
Goal: Error in recording one of the network stats should not result in completely empty network stats.

A process died and recording `snpm6` stats failed for that process which resulted in none of network stats being recorded. Error:
```
Sep 26 21:11:49 ip-10-66-6-18 below[21496]: Sep 27 04:11:49.866 ERRO Os { code: 2, kind: NotFound, message: "No such file or directory" }: "/proc/21496/net/snmp6"
```
