### PR TITLE
Remove URL popup

### DIFF
--- a/below/view/src/controllers/mod.rs
+++ b/below/view/src/controllers/mod.rs
@@ -135,5 +135,4 @@ make_controllers!(
     PrevPage: PrevPageImpl,
     NextSelection: NextSelectionImpl,
     PrevSelection: PrevSelectionImpl,
-    Url: URLPopup,
 );

--- a/below/view/src/controllers/open_source/mod.rs
+++ b/below/view/src/controllers/open_source/mod.rs
@@ -19,14 +19,6 @@ use crate::stats_view::StatsView;
 use crate::stats_view::ViewBridge;
 
 make_event_controller!(
-    URLPopup,
-    "__unused_url",
-    "",
-    vec![Event::Char('u')],
-    |_, _| {},
-    |_, _| {}
-);
-make_event_controller!(
     GpuView,
     "__unused_gpu",
     "",

--- a/below/view/src/controllers/test.rs
+++ b/below/view/src/controllers/test.rs
@@ -49,7 +49,6 @@ filter = 'u'
 clear_filter = 'v'
 next_page = 'Y'
 prev_page = 'y'
-url = 'n'
 ";
     let cmdrc_val = std::str::from_utf8(cmdrc_str)
         .expect("Failed to parse [u8] to str")
@@ -148,10 +147,6 @@ url = 'n'
     assert_eq!(
         event_controllers.get(&Event::Char('y')),
         Some(&Controllers::PrevPage)
-    );
-    assert_eq!(
-        event_controllers.get(&Event::Char('n')),
-        Some(&Controllers::Url)
     );
 }
 

--- a/below/view/src/help_menu.rs
+++ b/below/view/src/help_menu.rs
@@ -102,7 +102,6 @@ fn get_description(controller: &Controllers) -> &'static str {
         Controllers::Fold => "Fold processes (post filter) and display aggregated values.",
         Controllers::NextPage => "Scroll down 15 lines primary display.",
         Controllers::PrevPage => "Scroll up 15 lines primary display.",
-        Controllers::Url => "Show Corresponding Below Web URL.",
         _ => "Unknown",
     }
 }


### PR DESCRIPTION
Summary: URL popup is no longer used internally. Let's remove it.

Reviewed By: dschatzberg

Differential Revision: D54697749


