### PR TITLE
Bump to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "below"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "below-common",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "below-btrfs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "below-common",
  "libc",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "below-common"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "below-config"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "below-btrfs",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "below-dump"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "below-common",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "below-ethtool"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "nix 0.25.0",
  "serde",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "below-gpu-stats"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "below-common",
  "serde",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "below-model"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "below-render"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "below-common",
  "below-model",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "below-store"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "below-common",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "below-view"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "below-common",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "below_derive"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -437,7 +437,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cgroupfs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "nix 0.25.0",
  "openat",
@@ -902,7 +902,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fb_procfs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1775,7 +1775,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "resctrlfs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "maplit",
  "nix 0.25.0",

--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "An interactive tool to view and record historical system data"
@@ -21,31 +21,31 @@ unit-scripts = "../etc"
 
 [dependencies]
 anyhow = "1.0.75"
-cgroupfs = { version = "0.7.1", path = "cgroupfs" }
+cgroupfs = { version = "0.8.0", path = "cgroupfs" }
 clap = { version = "4.5.2", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 clap_complete = "4.5.1"
-common = { package = "below-common", version = "0.7.1", path = "common" }
-config = { package = "below-config", version = "0.7.1", path = "config" }
+common = { package = "below-common", version = "0.8.0", path = "common" }
+config = { package = "below-config", version = "0.8.0", path = "config" }
 cursive = { version = "0.20.0", features = ["crossterm-backend"], default-features = false }
-dump = { package = "below-dump", version = "0.7.1", path = "dump" }
+dump = { package = "below-dump", version = "0.8.0", path = "dump" }
 indicatif = { version = "0.17.6", features = ["improved_unicode", "rayon", "tokio"] }
 libbpf-rs = { version = "0.22", git = "https://github.com/libbpf/libbpf-rs.git", rev = "56dca575089ab2144f51b7949a9ee4c9fc226a47", default-features = false }
 libc = "0.2.139"
-model = { package = "below-model", version = "0.7.1", path = "model" }
+model = { package = "below-model", version = "0.8.0", path = "model" }
 once_cell = "1.12"
 plain = "0.2"
-procfs = { package = "fb_procfs", version = "0.7.1", path = "procfs" }
+procfs = { package = "fb_procfs", version = "0.8.0", path = "procfs" }
 regex = "1.9.2"
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 signal-hook = "0.3"
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
 slog-term = "2.8"
-store = { package = "below-store", version = "0.7.1", path = "store" }
+store = { package = "below-store", version = "0.8.0", path = "store" }
 tar = "0.4.40"
 tempfile = "3.8"
 tokio = { version = "1.36.0", features = ["full", "test-util", "tracing"] }
 uzers = "0.11.3"
-view = { package = "below-view", version = "0.7.1", path = "view" }
+view = { package = "below-view", version = "0.8.0", path = "view" }
 
 [dev-dependencies]
 maplit = "1.0"

--- a/below/below_derive/Cargo.toml
+++ b/below/below_derive/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below_derive"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Proc macros for below"

--- a/below/btrfs/Cargo.toml
+++ b/below/btrfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-btrfs"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "A crate for reading btrfs"
@@ -11,7 +11,7 @@ repository = "https://github.com/facebookincubator/below"
 license = "Apache-2.0"
 
 [dependencies]
-common = { package = "below-common", version = "0.7.1", path = "../common" }
+common = { package = "below-common", version = "0.8.0", path = "../common" }
 libc = "0.2.139"
 nix = "0.25"
 openat = "0.1.21"

--- a/below/cgroupfs/Cargo.toml
+++ b/below/cgroupfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "cgroupfs"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "A crate for reading cgroupv2 data"

--- a/below/common/Cargo.toml
+++ b/below/common/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-common"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Common below code"

--- a/below/config/Cargo.toml
+++ b/below/config/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-config"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Configurations for below"
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.75"
-btrfs = { package = "below-btrfs", version = "0.7.1", path = "../btrfs" }
-cgroupfs = { version = "0.7.1", path = "../cgroupfs" }
+btrfs = { package = "below-btrfs", version = "0.8.0", path = "../btrfs" }
+cgroupfs = { version = "0.8.0", path = "../cgroupfs" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 toml = "0.8.4"
 

--- a/below/dump/Cargo.toml
+++ b/below/dump/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-dump"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Dump crate for below"
@@ -11,17 +11,17 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.75"
-below_derive = { version = "0.7.1", path = "../below_derive" }
+below_derive = { version = "0.8.0", path = "../below_derive" }
 clap = { version = "4.5.2", features = ["derive", "env", "string", "unicode", "wrap_help"] }
-common = { package = "below-common", version = "0.7.1", path = "../common" }
+common = { package = "below-common", version = "0.8.0", path = "../common" }
 enum-iterator = "1.4.1"
-model = { package = "below-model", version = "0.7.1", path = "../model" }
+model = { package = "below-model", version = "0.8.0", path = "../model" }
 once_cell = "1.12"
 regex = "1.9.2"
-render = { package = "below-render", version = "0.7.1", path = "../render" }
+render = { package = "below-render", version = "0.8.0", path = "../render" }
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
-store = { package = "below-store", version = "0.7.1", path = "../store" }
+store = { package = "below-store", version = "0.8.0", path = "../store" }
 tar = "0.4.40"
 tempfile = "3.8"
 toml = "0.8.4"

--- a/below/ethtool/Cargo.toml
+++ b/below/ethtool/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-ethtool"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Model crate for below"

--- a/below/gpu_stats/Cargo.toml
+++ b/below/gpu_stats/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-gpu-stats"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "GPU stats crate for below"
@@ -10,5 +10,5 @@ repository = "https://github.com/facebookincubator/below"
 license = "Apache-2.0"
 
 [dependencies]
-common = { package = "below-common", version = "0.7.1", path = "../common" }
+common = { package = "below-common", version = "0.8.0", path = "../common" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }

--- a/below/model/Cargo.toml
+++ b/below/model/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-model"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Model crate for below"
@@ -12,18 +12,18 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.75"
 async-trait = "0.1.71"
-below_derive = { version = "0.7.1", path = "../below_derive" }
-btrfs = { package = "below-btrfs", version = "0.7.1", path = "../btrfs" }
-cgroupfs = { version = "0.7.1", path = "../cgroupfs" }
-common = { package = "below-common", version = "0.7.1", path = "../common" }
+below_derive = { version = "0.8.0", path = "../below_derive" }
+btrfs = { package = "below-btrfs", version = "0.8.0", path = "../btrfs" }
+cgroupfs = { version = "0.8.0", path = "../cgroupfs" }
+common = { package = "below-common", version = "0.8.0", path = "../common" }
 enum-iterator = "1.4.1"
-ethtool = { package = "below-ethtool", version = "0.7.1", path = "../ethtool" }
-gpu-stats = { package = "below-gpu-stats", version = "0.7.1", path = "../gpu_stats" }
+ethtool = { package = "below-ethtool", version = "0.8.0", path = "../ethtool" }
+gpu-stats = { package = "below-gpu-stats", version = "0.8.0", path = "../gpu_stats" }
 hostname = "0.3"
 os_info = "3.0.7"
-procfs = { package = "fb_procfs", version = "0.7.1", path = "../procfs" }
+procfs = { package = "fb_procfs", version = "0.8.0", path = "../procfs" }
 regex = "1.9.2"
-resctrlfs = { version = "0.7.1", path = "../resctrlfs" }
+resctrlfs = { version = "0.8.0", path = "../resctrlfs" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }

--- a/below/procfs/Cargo.toml
+++ b/below/procfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "fb_procfs"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "A crate for reading procfs"

--- a/below/render/Cargo.toml
+++ b/below/render/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-render"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Render crate for below"
@@ -10,5 +10,5 @@ repository = "https://github.com/facebookincubator/below"
 license = "Apache-2.0"
 
 [dependencies]
-common = { package = "below-common", version = "0.7.1", path = "../common" }
-model = { package = "below-model", version = "0.7.1", path = "../model" }
+common = { package = "below-common", version = "0.8.0", path = "../common" }
+model = { package = "below-model", version = "0.8.0", path = "../model" }

--- a/below/resctrlfs/Cargo.toml
+++ b/below/resctrlfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "resctrlfs"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "A crate for reading resctrl fs data"

--- a/below/store/Cargo.toml
+++ b/below/store/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-store"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Store crate for below"
@@ -13,11 +13,11 @@ license = "Apache-2.0"
 anyhow = "1.0.75"
 bitflags = { version = "2.4", features = ["serde"] }
 bytes = { version = "1.1", features = ["serde"] }
-common = { package = "below-common", version = "0.7.1", path = "../common" }
+common = { package = "below-common", version = "0.8.0", path = "../common" }
 humantime = "2.1"
 maplit = "1.0"
 memmap2 = "0.5.10"
-model = { package = "below-model", version = "0.7.1", path = "../model" }
+model = { package = "below-model", version = "0.8.0", path = "../model" }
 nix = "0.25"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_cbor = "0.11"

--- a/below/view/Cargo.toml
+++ b/below/view/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-view"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "View crate for below"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.75"
 chrono = { version = "0.4", features = ["clock", "serde", "std"], default-features = false }
-common = { package = "below-common", version = "0.7.1", path = "../common" }
+common = { package = "below-common", version = "0.8.0", path = "../common" }
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 cursive = { version = "0.20.0", features = ["crossterm-backend"], default-features = false }
 cursive_buffered_backend = "0.6.1"
@@ -20,12 +20,12 @@ enum-iterator = "1.4.1"
 humantime = "2.1"
 itertools = "0.11.0"
 libc = "0.2.139"
-model = { package = "below-model", version = "0.7.1", path = "../model" }
+model = { package = "below-model", version = "0.8.0", path = "../model" }
 once_cell = "1.12"
-render = { package = "below-render", version = "0.7.1", path = "../render" }
+render = { package = "below-render", version = "0.8.0", path = "../render" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
-store = { package = "below-store", version = "0.7.1", path = "../store" }
+store = { package = "below-store", version = "0.8.0", path = "../store" }
 toml = "0.8.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Summary:
Notable changes since 0.7.1:
* Support for ethtool stats.
* New cgroup stats including per-cgroup zswap memory usage, memory.min
  and kernel field from memory.stat.
* /sys/fs/resctrl data collection.
* /proc/slabinfo collection and display.
* viewrc support for `cgroup_name_width` to configure cgroup view name
  column width.

Fixes:
* Exitstat bpf program is fixed.

Differential Revision: D55491440


