### PR TITLE
Bump to 0.8.1

### DIFF
--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "An interactive tool to view and record historical system data"
@@ -21,31 +21,31 @@ unit-scripts = "../etc"
 
 [dependencies]
 anyhow = "1.0.75"
-cgroupfs = { version = "0.8.0", path = "cgroupfs" }
+cgroupfs = { version = "0.8.1", path = "cgroupfs" }
 clap = { version = "4.5.2", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 clap_complete = "4.5.1"
-common = { package = "below-common", version = "0.8.0", path = "common" }
-config = { package = "below-config", version = "0.8.0", path = "config" }
+common = { package = "below-common", version = "0.8.1", path = "common" }
+config = { package = "below-config", version = "0.8.1", path = "config" }
 cursive = { version = "0.20.0", features = ["crossterm-backend"], default-features = false }
-dump = { package = "below-dump", version = "0.8.0", path = "dump" }
+dump = { package = "below-dump", version = "0.8.1", path = "dump" }
 indicatif = { version = "0.17.6", features = ["improved_unicode", "rayon", "tokio"] }
 libbpf-rs = { version = "0.23", default-features = false }
 libc = "0.2.139"
-model = { package = "below-model", version = "0.8.0", path = "model" }
+model = { package = "below-model", version = "0.8.1", path = "model" }
 once_cell = "1.12"
 plain = "0.2"
-procfs = { package = "fb_procfs", version = "0.8.0", path = "procfs" }
+procfs = { package = "fb_procfs", version = "0.8.1", path = "procfs" }
 regex = "1.9.2"
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 signal-hook = "0.3"
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
 slog-term = "2.8"
-store = { package = "below-store", version = "0.8.0", path = "store" }
+store = { package = "below-store", version = "0.8.1", path = "store" }
 tar = "0.4.40"
 tempfile = "3.8"
 tokio = { version = "1.36.0", features = ["full", "test-util", "tracing"] }
 uzers = "0.11.3"
-view = { package = "below-view", version = "0.8.0", path = "view" }
+view = { package = "below-view", version = "0.8.1", path = "view" }
 
 [dev-dependencies]
 maplit = "1.0"

--- a/below/below_derive/Cargo.toml
+++ b/below/below_derive/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below_derive"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Proc macros for below"

--- a/below/btrfs/Cargo.toml
+++ b/below/btrfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-btrfs"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "A crate for reading btrfs"
@@ -11,7 +11,7 @@ repository = "https://github.com/facebookincubator/below"
 license = "Apache-2.0"
 
 [dependencies]
-common = { package = "below-common", version = "0.8.0", path = "../common" }
+common = { package = "below-common", version = "0.8.1", path = "../common" }
 libc = "0.2.139"
 nix = "0.25"
 openat = "0.1.21"

--- a/below/cgroupfs/Cargo.toml
+++ b/below/cgroupfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "cgroupfs"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "A crate for reading cgroupv2 data"

--- a/below/common/Cargo.toml
+++ b/below/common/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-common"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Common below code"

--- a/below/config/Cargo.toml
+++ b/below/config/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-config"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Configurations for below"
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.75"
-btrfs = { package = "below-btrfs", version = "0.8.0", path = "../btrfs" }
-cgroupfs = { version = "0.8.0", path = "../cgroupfs" }
+btrfs = { package = "below-btrfs", version = "0.8.1", path = "../btrfs" }
+cgroupfs = { version = "0.8.1", path = "../cgroupfs" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 toml = "0.8.4"
 

--- a/below/dump/Cargo.toml
+++ b/below/dump/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-dump"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Dump crate for below"
@@ -11,17 +11,17 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.75"
-below_derive = { version = "0.8.0", path = "../below_derive" }
+below_derive = { version = "0.8.1", path = "../below_derive" }
 clap = { version = "4.5.2", features = ["derive", "env", "string", "unicode", "wrap_help"] }
-common = { package = "below-common", version = "0.8.0", path = "../common" }
+common = { package = "below-common", version = "0.8.1", path = "../common" }
 enum-iterator = "1.4.1"
-model = { package = "below-model", version = "0.8.0", path = "../model" }
+model = { package = "below-model", version = "0.8.1", path = "../model" }
 once_cell = "1.12"
 regex = "1.9.2"
-render = { package = "below-render", version = "0.8.0", path = "../render" }
+render = { package = "below-render", version = "0.8.1", path = "../render" }
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
-store = { package = "below-store", version = "0.8.0", path = "../store" }
+store = { package = "below-store", version = "0.8.1", path = "../store" }
 tar = "0.4.40"
 tempfile = "3.8"
 toml = "0.8.4"

--- a/below/ethtool/Cargo.toml
+++ b/below/ethtool/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-ethtool"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Model crate for below"

--- a/below/ethtool/LICENSE
+++ b/below/ethtool/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/below/gpu_stats/Cargo.toml
+++ b/below/gpu_stats/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-gpu-stats"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "GPU stats crate for below"
@@ -10,5 +10,5 @@ repository = "https://github.com/facebookincubator/below"
 license = "Apache-2.0"
 
 [dependencies]
-common = { package = "below-common", version = "0.8.0", path = "../common" }
+common = { package = "below-common", version = "0.8.1", path = "../common" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }

--- a/below/model/Cargo.toml
+++ b/below/model/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-model"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Model crate for below"
@@ -12,18 +12,18 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.75"
 async-trait = "0.1.71"
-below_derive = { version = "0.8.0", path = "../below_derive" }
-btrfs = { package = "below-btrfs", version = "0.8.0", path = "../btrfs" }
-cgroupfs = { version = "0.8.0", path = "../cgroupfs" }
-common = { package = "below-common", version = "0.8.0", path = "../common" }
+below_derive = { version = "0.8.1", path = "../below_derive" }
+btrfs = { package = "below-btrfs", version = "0.8.1", path = "../btrfs" }
+cgroupfs = { version = "0.8.1", path = "../cgroupfs" }
+common = { package = "below-common", version = "0.8.1", path = "../common" }
 enum-iterator = "1.4.1"
-ethtool = { package = "below-ethtool", version = "0.8.0", path = "../ethtool" }
-gpu-stats = { package = "below-gpu-stats", version = "0.8.0", path = "../gpu_stats" }
+ethtool = { package = "below-ethtool", version = "0.8.1", path = "../ethtool" }
+gpu-stats = { package = "below-gpu-stats", version = "0.8.1", path = "../gpu_stats" }
 hostname = "0.3"
 os_info = "3.0.7"
-procfs = { package = "fb_procfs", version = "0.8.0", path = "../procfs" }
+procfs = { package = "fb_procfs", version = "0.8.1", path = "../procfs" }
 regex = "1.9.2"
-resctrlfs = { version = "0.8.0", path = "../resctrlfs" }
+resctrlfs = { version = "0.8.1", path = "../resctrlfs" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }

--- a/below/procfs/Cargo.toml
+++ b/below/procfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "fb_procfs"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "A crate for reading procfs"

--- a/below/render/Cargo.toml
+++ b/below/render/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-render"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Render crate for below"
@@ -10,5 +10,5 @@ repository = "https://github.com/facebookincubator/below"
 license = "Apache-2.0"
 
 [dependencies]
-common = { package = "below-common", version = "0.8.0", path = "../common" }
-model = { package = "below-model", version = "0.8.0", path = "../model" }
+common = { package = "below-common", version = "0.8.1", path = "../common" }
+model = { package = "below-model", version = "0.8.1", path = "../model" }

--- a/below/resctrlfs/Cargo.toml
+++ b/below/resctrlfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "resctrlfs"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "A crate for reading resctrl fs data"

--- a/below/resctrlfs/LICENSE
+++ b/below/resctrlfs/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/below/resctrlfs/README
+++ b/below/resctrlfs/README
@@ -1,0 +1,1 @@
+Crate to read resctrlfs data from /sys/fs/resctrl

--- a/below/store/Cargo.toml
+++ b/below/store/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-store"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "Store crate for below"
@@ -13,11 +13,11 @@ license = "Apache-2.0"
 anyhow = "1.0.75"
 bitflags = { version = "2.4", features = ["serde"] }
 bytes = { version = "1.1", features = ["serde"] }
-common = { package = "below-common", version = "0.8.0", path = "../common" }
+common = { package = "below-common", version = "0.8.1", path = "../common" }
 humantime = "2.1"
 maplit = "1.0"
 memmap2 = "0.5.10"
-model = { package = "below-model", version = "0.8.0", path = "../model" }
+model = { package = "below-model", version = "0.8.1", path = "../model" }
 nix = "0.25"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_cbor = "0.11"

--- a/below/view/Cargo.toml
+++ b/below/view/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "below-view"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Daniel Xu <dlxu@fb.com>", "Facebook"]
 edition = "2021"
 description = "View crate for below"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.75"
 chrono = { version = "0.4", features = ["clock", "serde", "std"], default-features = false }
-common = { package = "below-common", version = "0.8.0", path = "../common" }
+common = { package = "below-common", version = "0.8.1", path = "../common" }
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 cursive = { version = "0.20.0", features = ["crossterm-backend"], default-features = false }
 cursive_buffered_backend = "0.6.1"
@@ -20,12 +20,12 @@ enum-iterator = "1.4.1"
 humantime = "2.1"
 itertools = "0.11.0"
 libc = "0.2.139"
-model = { package = "below-model", version = "0.8.0", path = "../model" }
+model = { package = "below-model", version = "0.8.1", path = "../model" }
 once_cell = "1.12"
-render = { package = "below-render", version = "0.8.0", path = "../render" }
+render = { package = "below-render", version = "0.8.1", path = "../render" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
-store = { package = "below-store", version = "0.8.0", path = "../store" }
+store = { package = "below-store", version = "0.8.1", path = "../store" }
 toml = "0.8.4"
 
 [dev-dependencies]

--- a/scripts/publish_crates_io.py
+++ b/scripts/publish_crates_io.py
@@ -25,6 +25,7 @@ from os import path
 # Paths to crates relative to repository root
 # NB: Order the list based on dependencies: least deps first, most deps last
 PACKAGES = [
+    "below/ethtool",
     "below/cgroupfs",
     "below/procfs",
     "below/common",
@@ -32,6 +33,7 @@ PACKAGES = [
     "below/gpu_stats",
     "below/config",
     "below/below_derive",
+    "below/resctrlfs",
     "below/model",
     "below/render",
     "below/store",


### PR DESCRIPTION
Summary:
0.8.0 depended on an unreleased version of libbpf-rs preventing us
from releasing to crates.io.

Differential Revision: D55769523


