### PR TITLE
Setup log and store dir with systemd

### DIFF
--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -44,7 +44,6 @@ store = { package = "below-store", version = "0.8.1", path = "store" }
 tar = "0.4.43"
 tempfile = "3.15"
 tokio = { version = "1.41.0", features = ["full", "test-util", "tracing"] }
-uzers = "0.11.3"
 view = { package = "below-view", version = "0.8.1", path = "view" }
 
 [dev-dependencies]

--- a/below/config/src/lib.rs
+++ b/below/config/src/lib.rs
@@ -56,8 +56,11 @@ pub struct BelowConfig {
 impl Default for BelowConfig {
     fn default() -> Self {
         BelowConfig {
-            log_dir: BELOW_DEFAULT_LOG.into(),
-            store_dir: BELOW_DEFAULT_STORE.into(),
+            log_dir: std::env::var_os("LOGS_DIRECTORY")
+                .map_or(BELOW_DEFAULT_LOG.into(), PathBuf::from),
+            store_dir: std::env::var_os("LOGS_DIRECTORY").map_or(BELOW_DEFAULT_STORE.into(), |d| {
+                PathBuf::from(d).join("store")
+            }),
             cgroup_root: cgroupfs::DEFAULT_CG_ROOT.into(),
             cgroup_filter_out: String::new(),
             enable_gpu_stats: false,

--- a/etc/below.service
+++ b/etc/below.service
@@ -17,6 +17,7 @@ Description=below system monitor recording daemon
 After=time-sync.target
 
 [Service]
+LogsDirectory=below
 ExecStart=/usr/bin/below record --retain-for-s 604800 --compress
 # Enable backtraces in errors
 Environment=RUST_LIB_BACKTRACE=1


### PR DESCRIPTION
Summary: Logging and storage directory is better setup by systemd. If the log dir is not created, let's just log errors to some temporary file instead.

Differential Revision: D70026615


