### PR TITLE
Update cursive 0.20.0 -> 0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,6 @@ dependencies = [
  "chrono",
  "crossterm 0.28.1",
  "cursive",
- "cursive_buffered_backend",
  "enum-iterator",
  "fb_procfs",
  "humantime",
@@ -649,20 +648,6 @@ dependencies = [
  "signal-hook",
  "unicode-segmentation",
  "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "cursive_buffered_backend"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6287f9e06f44558a3264976e70c51187482a0271d48abfd88f0d3af18d3ee6"
-dependencies = [
- "cursive_core",
- "enumset",
- "log",
- "smallvec",
- "unicode-segmentation",
- "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -26,7 +26,7 @@ clap = { version = "4.5.38", features = ["derive", "env", "string", "unicode", "
 clap_complete = "4.5.50"
 common = { package = "below-common", version = "0.9.0", path = "common" }
 config = { package = "below-config", version = "0.9.0", path = "config" }
-cursive = { version = "0.20.0", features = ["crossterm-backend"], default-features = false }
+cursive = { version = "0.21.1", features = ["crossterm-backend"], default-features = false }
 dump = { package = "below-dump", version = "0.9.0", path = "dump" }
 indicatif = { version = "0.17.6", features = ["futures", "improved_unicode", "rayon", "tokio"] }
 libbpf-rs = { version = "=0.25.0-beta.1", default-features = false }

--- a/below/common/Cargo.toml
+++ b/below/common/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.98"
 chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }
-cursive = { version = "0.20.0", features = ["crossterm-backend"], default-features = false }
+cursive = { version = "0.21.1", features = ["crossterm-backend"], default-features = false }
 humantime = "2.1"
 once_cell = "1.12"
 regex = "1.11.1"

--- a/below/store/src/advance.rs
+++ b/below/store/src/advance.rs
@@ -76,7 +76,7 @@ impl SamplePackage<DataFrame> {
 }
 
 /// The store trait defines how should we get a sample from a Store
-trait ModelStore: Store {
+trait ModelStore: Store + Send + Sync {
     // For LocalStore and RemoteStore, ModelType will be Model
     // For FakeStore, ModelType will be string
     type ModelType;

--- a/below/store/src/compression.rs
+++ b/below/store/src/compression.rs
@@ -22,10 +22,10 @@ use bytes::Bytes;
 /// This file defines a minimalistic compressor and decompressor interface
 /// optimized for below's usage. They are wrappers around general compression
 /// libraries. Currently only zstd is supported.
-
+//
 // TODO: Use latest zstd as implementation
 // TODO: Consider using experimental feature to load dict by reference
-
+//
 fn code_to_err(code: zstd_safe::ErrorCode) -> Error {
     anyhow!(zstd_safe::get_error_name(code))
 }

--- a/below/store/src/lib.rs
+++ b/below/store/src/lib.rs
@@ -399,8 +399,10 @@ impl StoreWriter {
 
     /// For the given `DataFrame` and an optional Compressor mut ref, returns a
     /// tuple consisting of:
+    ///
     ///   1) Raw bytes to write to the data file
     ///   2) Flags to write to the index entry
+    ///
     /// For compressed write, the Compressor will be initialized if None, and
     /// potentially updated. is_key_frame is used to indicate the start of a new
     /// chunk if dictionary compression is enabled.
@@ -731,7 +733,7 @@ pub fn read_next_sample<P: AsRef<Path>>(
     cursor.get_next(&get_unix_timestamp(timestamp), direction)
 }
 
-pub trait Store {
+pub trait Store: Send + Sync {
     // We intentionally make this trait generic which not tied to the DataFrame and Model
     // type for ease of testing.
     // For LocalStore and RemoteStore, SampleType will be DataFrame

--- a/below/view/Cargo.toml
+++ b/below/view/Cargo.toml
@@ -14,8 +14,7 @@ anyhow = "1.0.98"
 chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }
 common = { package = "below-common", version = "0.9.0", path = "../common" }
 crossterm = { version = "0.28", features = ["event-stream"] }
-cursive = { version = "0.20.0", features = ["crossterm-backend"], default-features = false }
-cursive_buffered_backend = "0.6.1"
+cursive = { version = "0.21.1", features = ["crossterm-backend"], default-features = false }
 enum-iterator = "1.4.1"
 humantime = "2.1"
 itertools = "0.14.0"

--- a/below/view/src/cgroup_tabs.rs
+++ b/below/view/src/cgroup_tabs.rs
@@ -116,7 +116,8 @@ impl CgroupTab {
 
             let collapsed = state
                 .collapsed_cgroups
-                .borrow()
+                .lock()
+                .unwrap()
                 .contains(&cgroup.data.full_path);
             let row = self.get_line(&cgroup.data, collapsed, offset, cgroup.recreate_flag);
             // Each row is (label, value), where label is visible and value is used
@@ -146,7 +147,8 @@ impl CgroupTab {
                 for child_cgroup in &children {
                     state
                         .collapsed_cgroups
-                        .borrow_mut()
+                        .lock()
+                        .unwrap()
                         .insert(child_cgroup.data.full_path.clone());
                 }
             }

--- a/below/view/src/controllers/content_controllers.rs
+++ b/below/view/src/controllers/content_controllers.rs
@@ -23,7 +23,7 @@ make_event_controller!(
     vec![Event::Char('S')],
     |view: &mut StatsView<T>, cmd_vec: &[&str]| {
         let (sort_res, title) = if cmd_vec.len() > 1 {
-            let mut state = view.state.borrow_mut();
+            let mut state = view.state.lock().unwrap();
             let selection = cmd_vec[1..].join(" ");
             let sort_res = state.set_sort_string(&selection, &mut view.reverse_sort);
             (sort_res, selection)
@@ -33,7 +33,7 @@ make_event_controller!(
             let title_view = view.get_title_view();
             let title_idx = title_view.current_selected;
             let title = title_view.get_cur_selected().to_string();
-            let sort_res = view.state.borrow_mut().set_sort_tag_from_tab_idx(
+            let sort_res = view.state.lock().unwrap().set_sort_tag_from_tab_idx(
                 tab,
                 title_idx,
                 &mut view.reverse_sort,
@@ -43,7 +43,7 @@ make_event_controller!(
 
         if !sort_res {
             view.get_cmd_palette()
-                .set_alert(&format!("\"{}\" is not sortable currently.", title.trim()));
+                .set_alert(format!("\"{}\" is not sortable currently.", title.trim()));
         }
     },
     |c: &mut Cursive, _cmd_vec: &[&str]| {
@@ -71,14 +71,16 @@ make_event_controller!(
         };
         // don't enable str filter for unsupported fields
         if state
-            .borrow()
+            .lock()
+            .unwrap()
             .is_filter_supported_from_tab_idx(&tab, title_idx)
         {
             // set filter to cp
             if cmd_vec.len() > 1 {
                 let text = cmd_vec[1..].join(" ");
                 state
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .set_filter_from_tab_idx(&tab, title_idx, Some(text.clone()));
                 StatsView::<T>::cp_filter(c, Some((title_name, text)));
                 StatsView::<T>::refresh_myself(c);
@@ -104,7 +106,7 @@ make_event_controller!(
     |_view: &mut StatsView<T>, _cmd_vec: &[&str]| {},
     |c: &mut Cursive, _cmd_vec: &[&str]| {
         let state = StatsView::<T>::get_view(c).state.clone();
-        state.borrow_mut().set_filter_from_tab_idx("", 0, None); // clear filter
+        state.lock().unwrap().set_filter_from_tab_idx("", 0, None); // clear filter
         StatsView::<T>::cp_filter(c, None);
         StatsView::<T>::refresh_myself(c);
     }

--- a/below/view/src/controllers/controller_infra.rs
+++ b/below/view/src/controllers/controller_infra.rs
@@ -306,7 +306,7 @@ macro_rules! make_controllers {
                     .clone();
 
                 value.as_table().map(|table| table.iter().for_each(|(k, v)| {
-                    match (cmd_controllers.borrow().get::<str>(k), v.as_array()) {
+                    match (cmd_controllers.lock().unwrap().get::<str>(k), v.as_array()) {
                         (Some(controller), Some(key_array)) => {
                             for event_item in key_array.iter() {
                                 match event_item.as_str() {

--- a/below/view/src/controllers/mod.rs
+++ b/below/view/src/controllers/mod.rs
@@ -29,6 +29,7 @@
 //! * default_events: An array of default event triggers for this EventController
 //! * handle: How should below handle such event given the currst StatsView<T>
 //! * callback: How should below handle such event with a cursive object.
+//!
 //! EventController is a interface ONLY struct.
 //!
 //! ## Controllers
@@ -58,8 +59,8 @@
 //! 1. User typed something when not in the "command mode". For example "c".
 //! 2. StatsView<T> capture the cursive event. For example Event::char('c').
 //! 3. StatsView<T> trys to find the corresponding Controllers value in event_controller_map
-//!   3.1 if not found, send the event to its parent and return.
-//!   3.2 if found, get the Controllers value. For example Controllers::Cgroup.
+//!    3.1 if not found, send the event to its parent and return.
+//!    3.2 if found, get the Controllers value. For example Controllers::Cgroup.
 //! 4. Invoke the handle function. For example Controllers::Cgroup.hanle()
 //! 5. Invoke the callback function. For example Controllers::Cgroup.callback()
 //! 6. Mark the event as consumed.
@@ -67,10 +68,11 @@
 //! ## Command to EventController
 //! 1. User typed something in "command mode" and hit enter. For example: "cgroup".
 //! 2. CommandPalette capture the input and try to find the corresponding Controllers value in cmd_controller_map
-//!   2.1 if not found, raise error message
-//!   2.2 if found, get the Controllers value. For example Controllers::Cgroup
+//!    2.1 if not found, raise error message
+//!    2.2 if found, get the Controllers value. For example Controllers::Cgroup
 //! 3. Invoke the handle function. For example Controllers::Cgroup.hanle()
 //! 4. Invoke the callback function. For example Controllers::Cgroup.callback()
+
 use cursive::Cursive;
 use cursive::event::Event;
 use cursive::event::EventTrigger;

--- a/below/view/src/controllers/sample_controllers.rs
+++ b/below/view/src/controllers/sample_controllers.rs
@@ -83,7 +83,7 @@ make_event_controller!(
             .clone();
         match mode {
             ViewMode::Pause(adv) | ViewMode::Replay(adv) => {
-                let mut adv = adv.borrow_mut();
+                let mut adv = adv.lock().unwrap();
                 advance!(c, adv, Direction::Forward);
             }
             _ => {}
@@ -109,7 +109,7 @@ make_event_controller!(
             .clone();
         match mode {
             ViewMode::Pause(adv) | ViewMode::Replay(adv) => {
-                let mut adv = adv.borrow_mut();
+                let mut adv = adv.lock().unwrap();
                 advance!(c, adv, Direction::Reverse);
             }
             _ => {}
@@ -134,12 +134,12 @@ make_event_controller!(
             match &view_state.mode {
                 ViewMode::Pause(adv) => {
                     // On resume, we need to jump back to latest sample
-                    adv.borrow_mut().get_latest_sample();
+                    adv.lock().unwrap().get_latest_sample();
                     view_state.mode = ViewMode::Live(adv.clone());
                 }
                 ViewMode::Live(adv) => {
                     // If it's live local, we need to jump to the lastest sample
-                    adv.borrow_mut().get_latest_sample();
+                    adv.lock().unwrap().get_latest_sample();
                     view_state.mode = ViewMode::Pause(adv.clone());
                 }
                 _ => {}

--- a/below/view/src/controllers/test.rs
+++ b/below/view/src/controllers/test.rs
@@ -324,7 +324,8 @@ next_col = 'd'
         .user_data::<ViewState>()
         .expect("No data stored in Cursive object!")
         .event_controllers
-        .borrow();
+        .lock()
+        .unwrap();
     assert_eq!(
         event_controllers.get(&Event::Char('b')),
         Some(&Controllers::NextTab)

--- a/below/view/src/controllers/view_controllers.rs
+++ b/below/view/src/controllers/view_controllers.rs
@@ -176,7 +176,8 @@ make_event_controller!(
         if current_state.is_process_zoom_state() {
             crate::process_view::ProcessView::get_process_view(c)
                 .state
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .reset_state_for_quiting_zoom();
         }
         c.user_data::<ViewState>()
@@ -205,7 +206,8 @@ make_event_controller!(
         if current_state.is_process_zoom_state() {
             crate::process_view::ProcessView::get_process_view(c)
                 .state
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .reset_state_for_quiting_zoom();
         }
         c.user_data::<ViewState>()
@@ -234,7 +236,8 @@ make_event_controller!(
         if current_state.is_process_zoom_state() {
             crate::process_view::ProcessView::get_process_view(c)
                 .state
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .reset_state_for_quiting_zoom();
         }
         c.user_data::<ViewState>()
@@ -265,17 +268,20 @@ make_event_controller!(
                 if zoom != ProcessZoomState::NoZoom {
                     crate::process_view::ProcessView::get_process_view(c)
                         .state
-                        .borrow_mut()
+                        .lock()
+                        .unwrap()
                         .reset_state_for_quiting_zoom();
                 }
                 let selected_cgroup = crate::process_view::ProcessView::get_process_view(c)
                     .state
-                    .borrow()
+                    .lock()
+                    .unwrap()
                     .get_cgroup_for_selected_pid();
                 if let Some(cgroup) = selected_cgroup {
                     crate::cgroup_view::CgroupView::get_cgroup_view(c)
                         .state
-                        .borrow_mut()
+                        .lock()
+                        .unwrap()
                         .handle_state_for_entering_focus(cgroup);
                 } else {
                     // Probably no entries in process view. We still move to
@@ -286,12 +292,14 @@ make_event_controller!(
             MainViewState::Cgroup => {
                 let current_selection = crate::cgroup_view::CgroupView::get_cgroup_view(c)
                     .state
-                    .borrow()
+                    .lock()
+                    .unwrap()
                     .current_selected_cgroup
                     .clone();
                 crate::process_view::ProcessView::get_process_view(c)
                     .state
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .handle_state_for_entering_zoom(current_selection);
                 MainViewState::Process(ProcessZoomState::Cgroup)
             }
@@ -340,7 +348,7 @@ make_event_controller!(
         if current_state == MainViewState::Process(ProcessZoomState::NoZoom) {
             let mut process_view = crate::process_view::ProcessView::get_process_view(c);
             process_view.get_cmd_palette().toggle_fold();
-            process_view.state.borrow_mut().toggle_fold();
+            process_view.state.lock().unwrap().toggle_fold();
         }
 
         // Redraw screen now so we don't have to wait until next tick

--- a/below/view/src/help_menu.rs
+++ b/below/view/src/help_menu.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use cursive::event::Event;
 use cursive::view::Nameable;
@@ -129,14 +129,14 @@ fn get_title() -> Vec<String> {
 // Grab the user customized keymaps and generate helper message
 fn fill_controllers(
     v: &mut SelectView<String>,
-    event_controllers: Rc<RefCell<HashMap<Event, Controllers>>>,
+    event_controllers: Arc<Mutex<HashMap<Event, Controllers>>>,
 ) {
     // event_controllers can generate helper messages in completely random order base on
     // user's customization. Instead of using it directly, we will generate a cmd-msg map
     // to ensure the order.
     //
     let mut cmd_map: HashMap<Controllers, ControllerHelper> = HashMap::new();
-    for (event, controller) in event_controllers.borrow().iter() {
+    for (event, controller) in event_controllers.lock().unwrap().iter() {
         match cmd_map.get_mut(controller) {
             Some(ref mut item) => item.events.push(event.clone()),
             None => drop(cmd_map.insert(
@@ -209,7 +209,7 @@ fn fill_reserved(v: &mut LinearLayout) {
     }
 }
 
-pub fn new(event_controllers: Rc<RefCell<HashMap<Event, Controllers>>>) -> impl View {
+pub fn new(event_controllers: Arc<Mutex<HashMap<Event, Controllers>>>) -> impl View {
     let mut reserved = LinearLayout::vertical();
     fill_reserved(&mut reserved);
     let mut controllers = SelectView::<String>::new();

--- a/below/view/src/process_view.rs
+++ b/below/view/src/process_view.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::Ref;
-use std::cell::RefCell;
-use std::cell::RefMut;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
 
 use cursive::Cursive;
 use cursive::utils::markup::StyledString;
@@ -57,7 +56,7 @@ pub struct ProcessState {
     pub sort_tags: HashMap<String, &'static ProcessTab>,
     pub reverse: bool,
     pub fold: bool,
-    pub model: Rc<RefCell<ProcessModel>>,
+    pub model: Arc<Mutex<ProcessModel>>,
 }
 
 impl StateCommon for ProcessState {
@@ -134,15 +133,15 @@ impl StateCommon for ProcessState {
         }
     }
 
-    fn get_model(&self) -> Ref<Self::ModelType> {
-        self.model.borrow()
+    fn get_model(&self) -> MutexGuard<Self::ModelType> {
+        self.model.lock().unwrap()
     }
 
-    fn get_model_mut(&self) -> RefMut<Self::ModelType> {
-        self.model.borrow_mut()
+    fn get_model_mut(&self) -> MutexGuard<Self::ModelType> {
+        self.model.lock().unwrap()
     }
 
-    fn new(model: Rc<RefCell<Self::ModelType>>) -> Self {
+    fn new(model: Arc<Mutex<Self::ModelType>>) -> Self {
         let mut sort_tags = HashMap::new();
         sort_tags.insert("General".into(), &*PROCESS_GENERAL_TAB);
         sort_tags.insert("CPU".into(), &*PROCESS_CPU_TAB);
@@ -255,47 +254,52 @@ impl ProcessView {
         .on_event('P', |c| {
             let mut view = Self::get_process_view(c);
             view.state
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .set_sort_order(SingleProcessModelFieldId::Pid);
-            view.state.borrow_mut().set_reverse(false);
+            view.state.lock().unwrap().set_reverse(false);
             view.refresh(c)
         })
         .on_event('C', |c| {
             let mut view = Self::get_process_view(c);
             view.state
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .set_sort_order(SingleProcessModelFieldId::Cpu(
                     ProcessCpuModelFieldId::UsagePct,
                 ));
-            view.state.borrow_mut().set_reverse(true);
+            view.state.lock().unwrap().set_reverse(true);
             view.refresh(c)
         })
         .on_event('N', |c| {
             let mut view = Self::get_process_view(c);
             view.state
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .set_sort_order(SingleProcessModelFieldId::Comm);
-            view.state.borrow_mut().set_reverse(false);
+            view.state.lock().unwrap().set_reverse(false);
             view.refresh(c)
         })
         .on_event('M', |c| {
             let mut view = Self::get_process_view(c);
             view.state
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .set_sort_order(SingleProcessModelFieldId::Mem(
                     ProcessMemoryModelFieldId::RssBytes,
                 ));
-            view.state.borrow_mut().set_reverse(true);
+            view.state.lock().unwrap().set_reverse(true);
             view.refresh(c)
         })
         .on_event('D', |c| {
             let mut view = Self::get_process_view(c);
             view.state
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .set_sort_order(SingleProcessModelFieldId::Io(
                     ProcessIoModelFieldId::RwbytesPerSec,
                 ));
-            view.state.borrow_mut().set_reverse(true);
+            view.state.lock().unwrap().set_reverse(true);
             view.refresh(c)
         })
         .with_name(Self::get_view_name())

--- a/below/view/src/status_bar.rs
+++ b/below/view/src/status_bar.rs
@@ -54,7 +54,7 @@ fn get_content(c: &mut Cursive) -> impl Into<StyledString> + use<> {
     header_str.append_plain(format!(
         "{}{}{}",
         get_spacing(),
-        &view_state.system.borrow().hostname,
+        &view_state.system.lock().unwrap().hostname,
         get_spacing(),
     ));
 

--- a/below/view/src/summary_view.rs
+++ b/below/view/src/summary_view.rs
@@ -293,9 +293,9 @@ fn fill_content(c: &mut Cursive, v: &mut LinearLayout) {
         .user_data::<ViewState>()
         .expect("No data stored in Cursive object!");
 
-    let system_model = view_state.system.borrow();
-    let network_model = view_state.network.borrow();
-    let process_model = view_state.process.borrow();
+    let system_model = view_state.system.lock().unwrap();
+    let network_model = view_state.network.lock().unwrap();
+    let process_model = view_state.process.lock().unwrap();
     let cpu = render_impl::gather_cpu(&system_model);
     let mem = render_impl::gather_mem(&system_model);
     let vm = render_impl::gather_vm(&system_model);
@@ -312,7 +312,7 @@ fn fill_content(c: &mut Cursive, v: &mut LinearLayout) {
     view.add_child(pad(Panel::new(render_group(&io)).title("I/O")));
     view.add_child(pad(Panel::new(render_group(&iface)).title("Interface")));
 
-    let model = view_state.model.borrow();
+    let model = view_state.model.lock().unwrap();
     // TODO: Save the parsed extra rows in a struct and reuse
     let extra_groups = render_impl::get_summary_view_extra_group(&view_state.viewrc);
     for extra_group in extra_groups {


### PR DESCRIPTION
Summary:
This is an attempt to update cursive. What started this was a RUSTSEC on a transitive package but it became a bit of rabbit hole.

Anyway, this diff (please review, don't just stamp) updates cursive and it's (I think) only client, which is resctl.

This update comes with non-trivial breaking changes, in particular:

- The View now requires Send + Sync, to allow accessing or moving views between threads. This prevents using Rc/RefCell, and may require using Arc/Mutex instead. This should eventually open the way for more multi-threaded processing of the view tree.

Of course this requires changing pretty much everything that touches Views... which is a lot.

DevMate did a lot of the work once I got it in the right track. It builds and tests pass.

The other thing worth mentioning is that the crate cursive_buffered_backend is removed, because cursive now includes this according its CHANGELOG.

- The output to the backend is now buffered and delta-patched, resulting in improved performance for most backends.

Reviewed By: Imxset21

Differential Revision: D77703952


