### PR TITLE
Adding collectd and sysstat tool to comparsion docs

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -51,6 +51,40 @@ https://htop.dev/
 * No cgroup awareness
 * Limited host-level stats
 
+## sysstat (sar)
+
+https://github.com/sysstat/sysstat
+
+* CLI-based tools like `sar`, `iostat`, `pidstat`, and others  
+* Collects a wide range of system performance metrics (CPU, memory, IO, etc.)  
+* Mature and widely used for historical performance tracking  
+* Data can be collected periodically via `cron` or systemd timers  
+* Data stored in a binary format, accessible through CLI  
+
+### Drawbacks
+
+* No interactive or web interface  
+* Lacks container or cgroup-specific visibility  
+* Requires parsing and scripting to extract structured data  
+* Binary logs are not human-readable without `sar`  
+
+## collectd
+
+https://collectd.org/
+
+* Daemon-based metrics collector  
+* Plugin architecture for system and application metrics (disk, memory, network, etc.)  
+* Can push metrics to various backends (Graphite, InfluxDB, Prometheus via exporter)  
+* Lightweight and extensible with community plugins  
+* Suitable for long-term storage and visualization setups  
+
+### Drawbacks
+
+* No built-in UI or terminal interface  
+* Configuration can be complex  
+* Requires external tooling for data visualization  
+* No direct cgroup or container integration by default  
+
 ## below
 
 https://github.com/facebookincubator/below


### PR DESCRIPTION
## What this PR does

This PR updates the comparison document to include two additional tools: **sysstat (sar)** and **collectd**, in response to [#8255](https://github.com/facebookincubator/below/issues/8255).

Both tools are commonly used in system observability and performance monitoring, and adding them helps provide a more complete view of the ecosystem for potential users.

## Why this is needed

The request in issue [#8255](https://github.com/facebookincubator/below/issues/8255) highlighted the absence of `sysstat` and `collectd` in the current comparison doc. Including them:

- Acknowledges widely adopted monitoring tools in the Linux ecosystem.
- Helps users understand how `below` compares with both daemon-based collectors and CLI-based utilities.

## Reference

Closes: https://github.com/facebookincubator/below/issues/8255
