### PR TITLE
Update crate tempfile 3.15 -> 3.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       run: >
         docker build
         -t below
-        --target build
+        --target builder
         .
     - name: Run tests
       # Skip tests that require host to have cgroup2

--- a/below/Cargo.toml
+++ b/below/Cargo.toml
@@ -44,7 +44,7 @@ slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
 slog-term = "2.8"
 store = { package = "below-store", version = "0.10.0", path = "store" }
 tar = "0.4.44"
-tempfile = "3.15"
+tempfile = "3.22"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 view = { package = "below-view", version = "0.10.0", path = "view" }
 

--- a/below/cgroupfs/Cargo.toml
+++ b/below/cgroupfs/Cargo.toml
@@ -19,4 +19,4 @@ thiserror = "2.0.12"
 
 [dev-dependencies]
 paste = "1.0.14"
-tempfile = "3.15"
+tempfile = "3.22"

--- a/below/common/Cargo.toml
+++ b/below/common/Cargo.toml
@@ -21,4 +21,4 @@ slog-term = "2.8"
 walkdir = "2.3"
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = "3.22"

--- a/below/config/Cargo.toml
+++ b/below/config/Cargo.toml
@@ -17,4 +17,4 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 toml = { version = "0.9.2", features = ["preserve_order"] }
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = "3.22"

--- a/below/dump/Cargo.toml
+++ b/below/dump/Cargo.toml
@@ -23,5 +23,5 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
 store = { package = "below-store", version = "0.10.0", path = "../store" }
 tar = "0.4.44"
-tempfile = "3.15"
+tempfile = "3.22"
 toml = { version = "0.9.2", features = ["preserve_order"] }

--- a/below/procfs/Cargo.toml
+++ b/below/procfs/Cargo.toml
@@ -24,4 +24,4 @@ threadpool = "1.8.1"
 
 [dev-dependencies]
 slog-term = "2.8"
-tempfile = "3.15"
+tempfile = "3.22"

--- a/below/resctrlfs/Cargo.toml
+++ b/below/resctrlfs/Cargo.toml
@@ -19,4 +19,4 @@ thiserror = "2.0.12"
 [dev-dependencies]
 maplit = "1.0"
 paste = "1.0.14"
-tempfile = "3.15"
+tempfile = "3.22"

--- a/below/store/Cargo.toml
+++ b/below/store/Cargo.toml
@@ -30,7 +30,7 @@ itertools = "0.14.0"
 lazy_static = "1.5"
 paste = "1.0.14"
 slog-term = "2.8"
-tempfile = "3.15"
+tempfile = "3.22"
 zstd = { version = "0.13", features = ["experimental", "zstdmt"] }
 
 [features]

--- a/below/view/Cargo.toml
+++ b/below/view/Cargo.toml
@@ -29,4 +29,4 @@ store = { package = "below-store", version = "0.10.0", path = "../store" }
 toml = { version = "0.9.2", features = ["preserve_order"] }
 
 [dev-dependencies]
-tempfile = "3.15"
+tempfile = "3.22"


### PR DESCRIPTION
Summary:
Reason: below build is broken. Apparently the code was updated but the dependency wasn't? I don't know, but the github action has been failing for a month.

No idea who should fix it but I'm annoyed enough.

Differential Revision: D82367478
